### PR TITLE
Store Transaction Output amounts as Values

### DIFF
--- a/integration-test/test/test_all.py
+++ b/integration-test/test/test_all.py
@@ -278,7 +278,8 @@ class TestAll:
 
         non_nft_utxo = None
         for utxo in self.chain_context.utxos(str(taker_address)):
-            if isinstance(utxo.output.amount, int):
+            # multi_asset should be empty for collateral utxo
+            if not utxo.output.amount.multi_asset:
                 non_nft_utxo = utxo
                 break
 

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -255,6 +255,10 @@ class TransactionOutput(ArrayCBORSerializable):
 
     datum_hash: DatumHash = field(default=None, metadata={"optional": True})
 
+    def __post_init__(self):
+        if isinstance(self.amount, int):
+            self.amount = Value(self.amount)
+
     def validate(self):
         if isinstance(self.amount, int) and self.amount < 0:
             raise InvalidDataException(

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -246,6 +246,12 @@ class Value(ArrayCBORSerializable):
     def __lt__(self, other: Union[Value, int]):
         return self <= other and self != other
 
+    def to_shallow_primitive(self):
+        if self.multi_asset:
+            return super().to_shallow_primitive()
+        else:
+            return self.coin
+
 
 @dataclass(repr=False)
 class TransactionOutput(ArrayCBORSerializable):

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -412,7 +412,7 @@ def test_not_enough_input_amount(chain_context):
 
     # Make output amount equal to the input amount
     tx_builder.add_input(input_utxo).add_output(
-        TransactionOutput.from_primitive([sender, input_utxo.output.amount])
+        TransactionOutput(Address.from_primitive(sender), input_utxo.output.amount)
     )
 
     with pytest.raises(UTxOSelectionException):


### PR DESCRIPTION
The purpose of this PR is to help make UTxO math a bit easier.
At the moment, one cannot add the amounts of `TransactionOutput`s together easily.

An example of why this might be useful is:

```python
# add outputs to a transaction with builder 

builder.outputs[0] += Value(coin=5_000_000)

# or even 
builder.outputs[0] += 5_000_000
```

The above code works only if the `outputs[0]` is already a `Value`.  If it's an `int` it won't work. The current workaround is to do something like:
```python
builder.outputs[0] = Value(coin=5_000_000) + builder.outputs[0]
```

so that the value is the class handling the addition, but it might be a bit easier from a UTxO math standpoint if amounts were always `Value`s (but could still be initialized with `int`s.

There might be a problem with one of the tests but I'm having trouble debugging it.