### PR TITLE
Add usage guides for Plutus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ format: ## runs code style and formatter
 
 docs: ## build the documentation
 	poetry export --dev --without-hashes > docs/requirements.txt
+	rm -r -f docs/build
 	poetry run sphinx-build docs/source docs/build/html
 	$(BROWSER) docs/build/html/index.html
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ format: ## runs code style and formatter
 
 docs: ## build the documentation
 	poetry export --dev --without-hashes > docs/requirements.txt
-	rm -r docs/build
 	poetry run sphinx-build docs/source docs/build/html
 	$(BROWSER) docs/build/html/index.html
 

--- a/docs/source/guides/plutus.rst
+++ b/docs/source/guides/plutus.rst
@@ -1,0 +1,124 @@
+======
+Plutus
+======
+
+Plutus is the native language to write smart contract on Cardano's extended UTxO model (EUTxO). It allows us to incorporate expressive logics to determine when a particular UTxO can be spent.
+To learn more about EUTxO and its advantages, you can refer to the `Cardano docs <https://docs.cardano.org/plutus/eutxo-explainer>`_ or the `class notes <https://plutus-pioneer-program.readthedocs.io/en/latest/pioneer/week1.html>`_ from Plutus pioneer program (PPP).
+To learn how Plutus enables logic creation, we need to understand a couple key concepts:
+
+* **Plutus script**: the smart contract that acts as the validator of the transaction. By evaluating the inputs from someone who wants to spend the UTxO, they either approve or deny it (by returning either True or False). The script is compiled into Plutus Core binary and sits on-chain.
+* **Script address**: the hash of the Plutus script binary. They hold UTxOs like typical public key address, but every time a transaction tries to consume the UTxOs on this address, the Plutus script generated this address will be executed by evaluating the input of the transaction, namely datum, redeemer and script context. The transaction is only valid if the script returns True.
+* **Datum**: the datum is a piece of information associated with a UTxO. When someone sends fund to script address, he or she attaches the hash of the datum to "lock" the fund. When someone tries to consume the UTxO, he or she needs to provide datum whose hash matches the attached datum hash and redeemer that meets the conditions specified by the Plutus script to "unlock" the fund.
+* **Redeemer**: the redeemer shares the same data format as datum, but is a separate input. Redeemer value is attached to the input transaction to unlock funds from a script and is used by the script to validate the transaction.
+* **Script context**: The script context provides information about the pending transaction, along with which input triggered the validation.
+
+------------------
+Example - FortyTwo
+------------------
+
+We demonstrate how these concepts come into play using a simple example from PPP - FortyTwo. The original script in haskell can be found here `here <https://github.com/input-output-hk/plutus-pioneer-program/blob/28559d379df8b66c06d8fbd1e2a43f6a8351382a/code/week02/src/Week02/Typed.hs>`_. Using PyCardano, we will show one can send and lock funds at a script address, and how someone else with the correct redeemer value can unlock and receive the funds.
+
+Step 1
+
+Similar to `Transaction guide <../guides/transaction.html>`_, we build a chain context using `BlockFrostChainContext <../api/pycardano.backend.base.html#pycardano.backend.blockfrost.BlockFrostChainContext>`_::
+
+    >>> from pycardano import BlockFrostChainContext, Network
+    >>> network = Network.TESTNET
+    >>> context = BlockFrostChainContext("your_blockfrost_project_id", network)
+
+Step 2
+
+Create script address::
+
+    >>> import cbor2
+    >>> from pycardano import (
+    ...     Address,
+    ...     PaymentVerificationKey,
+    ...     PaymentSigningKey,
+    ...     plutus_script_hash,
+    ...     Transaction,
+    ...     TransactionBuilder,
+    ...     PlutusData,
+    ...     Redeemer,
+    ... )
+
+    >>> # Assuming the hexadecimal file of the script exists at your local path
+    >>> with open("path/to/fortytwo.plutus", "r") as f:
+    >>>     script_hex = f.read()
+    >>>     forty_two_script = cbor2.loads(bytes.fromhex(script_hex))
+
+    >>> script_hash = plutus_script_hash(forty_two_script)
+    >>> script_address = Address(script_hash, network=network)
+
+Step 3
+
+Giver/Locker sends funds to script address::
+
+    >>> payment_vkey = PaymentVerificationKey.load("path/to/payment.vkey")
+    >>> payment_skey = PaymentSigningKey.load("path/to/payment.skey")
+    >>> giver_address = Address(payment_vkey.hash(), network=network)
+
+    >>> builder = TransactionBuilder(context)
+    >>> builder.add_input_address(giver_address)
+
+    >>> datum = PlutusData()  # A Unit type "()" in Haskell
+    >>> builder.add_output(
+    >>>     TransactionOutput(script_address, 50000000, datum_hash=datum_hash(datum))
+    >>> )
+
+Build, sign and submit the transaction:
+
+    >>> signed_tx = builder.build_and_sign([payment_skey], giver_address)
+    >>> context.submit_tx(signed_tx.to_cbor())
+
+`PlutusData` helper class that can serialize itself into a CBOR format, which could be intepreted as a data structure in Plutus scripts. Wrapping datum in PlutusData class will reduce the complexity of serialization and deserialization tremendously. It supports data type of int, bytes, List and hashmap. For our example, we leave it empty. But to construct any arbitrary datum, we can do the following::
+
+    >>> # Create sample datum
+    >>> @dataclass
+    ... class Test(PlutusData):
+    ...     CONSTR_ID = 1
+    ...     a: int
+    ...     b: bytes
+
+    >>> test = Test(123, b"321")
+    >>> test.to_cbor()
+    'd87a9f187b43333231ff'
+    >>> assert test == Test.from_cbor("d87a9f187b43333231ff")
+    True
+
+Step 4
+
+Taker/Unlocker sends transaction to consume funds. Here we specify the redeemer tag as spend and pass in the redeemer value of 42. If the redeemer value is anything else, the validator will fail and funds won't be retrieved::
+
+    >>> redeemer = Redeemer(RedeemerTag.SPEND, 42)
+
+    >>> utxo_to_spend = context.utxos(str(script_address))[0]
+    >>> extended_payment_vkey = PaymentVerificationKey.load("path/to/extended_payment.vkey")
+    >>> extended_payment_skey = PaymentSigningKey.load("path/to/extended_payment.skey")
+    >>> taker_address = Address(extended_payment_vkey.hash(), network=network)
+
+    >>> builder = TransactionBuilder(context)
+
+Add info on the UTxO to spend, Plutus script, actual datum and the redeemer. Specify funds amount to take::
+
+    >>> builder.add_script_input(utxo_to_spend, forty_two_script, datum, redeemer)
+    >>> take_output = TransactionOutput(taker_address, 25123456)
+    >>> builder.add_output(take_output)
+
+Taker/Unlocker provides collateral. Collateral has been introduced in Alonzo transactions to cover the cost of the validating node executing a failing script. In this scenario, the provided UTXO is consumed instead of the fees. A UTXO provided for collateral must only have ada, no other native assets::
+
+    >>> non_nft_utxo = None
+    >>> for utxo in context.utxos(str(taker_address)):
+    >>>     # multi_asset should be empty for collateral utxo
+    >>>     if not utxo.output.amount.multi_asset:
+    >>>         non_nft_utxo = utxo
+    >>>         break
+
+    >>> builder.collaterals.append(non_nft_utxo)
+
+    >>> signed_tx = builder.build_and_sign([self.extended_payment_skey], taker_address)
+
+    >>> chain_context.submit_tx(signed_tx.to_cbor())
+
+The funds locked in script address is successfully retrieved to the taker address.
+

--- a/docs/source/guides/transaction.rst
+++ b/docs/source/guides/transaction.rst
@@ -103,7 +103,7 @@ Step 1
 
 To use a transaction builder, we first need to create a chain context, so the builder can read protocol parameters and
 search proper transaction inputs to use. Currently, the available chain context is
-`BlockFrostChainContext <api/pycardano.backend.base.html#pycardano.backend.blockfrost.BlockFrostChainContext>`_ ::
+`BlockFrostChainContext <../api/pycardano.backend.base.html#pycardano.backend.blockfrost.BlockFrostChainContext>`_ ::
 
     >>> from pycardano import BlockFrostChainContext, Network
     >>> network = Network.TESTNET

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,7 @@ making it a light-weight library that is easy and fast to set up in all kinds of
     guides/serialization
     guides/instance_creation
     guides/transaction
+    guides/plutus
 
 
 .. toctree::


### PR DESCRIPTION
- Add usage guides for Plutus - explained concepts such as script address, datum, redeemer, script context, etc. Demonstrated the use through FortyTwo example. 
- Minor fix to the hyperlink in Transaction.rst
- removed the "rm -r docs/build" commands before running Sphinx in Makefile