### PR TITLE
added support for staking address in cip08

### DIFF
--- a/pycardano/cip/cip8.py
+++ b/pycardano/cip/cip8.py
@@ -157,7 +157,7 @@ def verify(
             signing_address.payment_part
             == PaymentVerificationKey.from_primitive(verification_key).hash()
         )
-    elif signing_address.staking_part is not None:
+    else:
         addresses_match = (
             signing_address.staking_part
             == StakeVerificationKey.from_primitive(verification_key).hash()

--- a/pycardano/cip/cip8.py
+++ b/pycardano/cip/cip8.py
@@ -10,7 +10,7 @@ from cose.keys.keytype import KtyOKP
 from cose.messages import CoseMessage, Sign1Message
 
 from pycardano.address import Address
-from pycardano.key import PaymentVerificationKey, SigningKey, VerificationKey
+from pycardano.key import PaymentVerificationKey, SigningKey, StakeVerificationKey, VerificationKey
 from pycardano.network import Network
 
 
@@ -151,10 +151,17 @@ def verify(
 
     # check that the address attached matches the
     # one of the verification keys used to sign the message
-    addresses_match = (
-        signing_address.payment_part
-        == PaymentVerificationKey.from_primitive(verification_key).hash()
-    )
+
+    if signing_address.payment_part is not None:
+        addresses_match = (
+            signing_address.payment_part
+            == PaymentVerificationKey.from_primitive(verification_key).hash()
+        )
+    elif signing_address.staking_part is not None:
+        addresses_match = (
+            signing_address.staking_part
+            == StakeVerificationKey.from_primitive(verification_key).hash()
+        )
 
     verified = signature_verified & addresses_match
 

--- a/test/pycardano/test_cip8.py
+++ b/test/pycardano/test_cip8.py
@@ -48,6 +48,21 @@ def test_verify_message_cose_key_attached():
     )
 
 
+def test_verify_message_stake_address():
+    signed_message = {
+        "signature": "84582aa201276761646472657373581de0219f8e3ffefc82395df0bfcfe4e576f8f824bae0c731be35321c01d7a166686173686564f452507963617264616e6f20697320636f6f6c2e58402f2b75301a20876beba03ec68b30c5fbaebc99cb1d038b679340eb2299c2b75cd9c6c884c198e89f690548ee94a87168f5db34acf024d5788e58d119bcba630d",
+        "key": "a40101032720062158200d8e03b5673bf8dabc567dd6150ebcd56179a91a6c0b245f477033dcab7dc780"
+    }
+
+    verification = verify(signed_message, attach_cose_key=True)
+    assert verification["verified"]
+    assert verification["message"] == "Pycardano is cool."
+    assert (
+        str(verification["signing_address"])
+        == "stake_test1uqselr3llm7gyw2a7zlule89wmu0sf96urrnr034xgwqr4csd30df"
+    )
+
+
 def test_sign_message():
 
     message = "Pycardano is cool."


### PR DESCRIPTION
CIP 08 currently only supports payment addresses signatures. The following format for example:
```json
{
    "signature": "84582aa201276761646472657373581de0219f8e3ffefc82395df0bfcfe4e576f8f824bae0c731be35321c01d7a166686173686564f452507963617264616e6f20697320636f6f6c2e58402f2b75301a20876beba03ec68b30c5fbaebc99cb1d038b679340eb2299c2b75cd9c6c884c198e89f690548ee94a87168f5db34acf024d5788e58d119bcba630d",
    "key": "a40101032720062158200d8e03b5673bf8dabc567dd6150ebcd56179a91a6c0b245f477033dcab7dc780"
}
```

which was generated from Nami with the following code:
```javascript
const getSignedMessage = async (message) => {
  const sig = await curWallet.api.signData(
    rewardAddresses[0],
    toHex(message)
  );

  return sig;
};
```
was failing with the current implementation. This happened because the code always assumed we were using a payment_part (you can see this in line 158 of cip8.py):

```python3
# check that the address attached matches the
# one of the verification keys used to sign the message
addresses_match = (
    signing_address.payment_part
    == PaymentVerificationKey.from_primitive(verification_key).hash()
)
```
In this case `signing_address.payment_part` would be equal to None, which is not equal to `PaymentVerificationKey.from_primitive(verification_key).hash()`. So what I did was just to verify whethere we are using a payment part or a stake part. I didn't handle the case where both are None because I don't think that's possible, but I am open to ideas.