### PR TITLE
Fixing inconsistency between generated entropy value type and the expected HDWallet.entropy value type

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 omit =
-    pycardano/crypto/*
+    pycardano/crypto/bech32.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 cov_html
 docs/build
 dist
+
+# IDE
+.idea
+.code

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build format test help docs
+.PHONY: clean clean-test clean-pyc clean-build format test test-single help docs
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT
@@ -56,6 +56,9 @@ clean-test: ## remove test and coverage artifacts
 
 test: ## runs tests
 	poetry run pytest -s -vv -n 4
+
+test-single: ## runs tests with "single" markers
+	poetry run pytest -s -vv -m single
 
 qa: ## runs static analysis with flake8
 	poetry run flake8 pycardano

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build format test test-single help docs
+.PHONY: cov cov-html clean clean-test clean-pyc clean-build qa format test test-single help docs
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -109,6 +109,9 @@ class HDWallet:
 
         Args:
             seed: Master key of 96 bytes from seed hex string.
+            entropy: Entropy hex string, default to ``None``.
+            passphrase: Mnemonic passphrase or password, default to ``None``.
+            mnemonic: Mnemonic words, default to ``None``.
 
         Returns:
             HDWallet -- Hierarchical Deterministic Wallet instance.
@@ -168,7 +171,7 @@ class HDWallet:
         return cls.from_seed(
             seed=hexlify(seed).decode(),
             mnemonic=mnemonic,
-            entropy=entropy,
+            entropy=unhexlify(entropy).decode("utf-8"),
             passphrase=passphrase,
         )
 

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -171,7 +171,7 @@ class HDWallet:
         return cls.from_seed(
             seed=hexlify(seed).decode(),
             mnemonic=mnemonic,
-            entropy=unhexlify(entropy).decode("utf-8"),
+            entropy=hexlify(entropy).decode("utf-8"),
             passphrase=passphrase,
         )
 

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -569,15 +569,13 @@ class HDWallet:
             )
         try:
             mnemonic = unicodedata.normalize("NFKD", mnemonic)
-            if language is None:
-                for _language in SUPPORTED_MNEMONIC_LANGS:
-                    valid = False
-                    if Mnemonic(language=_language).check(mnemonic=mnemonic) is True:
-                        valid = True
-                        break
-                return valid
-            else:
+            if language:
                 return Mnemonic(language=language).check(mnemonic=mnemonic)
+
+            for _language in SUPPORTED_MNEMONIC_LANGS:
+                if Mnemonic(language=_language).check(mnemonic=mnemonic) is True:
+                    return True
+            return False
         except ValueError:
             logger.warning(
                 "The input mnemonic words are not valid. Words should be in string format seperated by space."

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -16,6 +16,8 @@ from typing import Optional
 from mnemonic import Mnemonic
 from nacl import bindings
 
+from pycardano.logging import logger
+
 __all__ = ["BIP32ED25519PrivateKey", "BIP32ED25519PublicKey", "HDWallet"]
 
 
@@ -581,7 +583,7 @@ class HDWallet:
             else:
                 return Mnemonic(language=language).check(mnemonic=mnemonic)
         except ValueError:
-            print(
+            logger.warning(
                 "The input mnemonic words are not valid. Words should be in string format seperated by space."
             )
 
@@ -600,4 +602,5 @@ class HDWallet:
         try:
             return len(unhexlify(entropy)) in [16, 20, 24, 28, 32]
         except ValueError:
-            print("The input entropy is not valid.")
+            logger.warning("The input entropy is not valid.")
+            return False

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -267,28 +267,26 @@ class HDWallet:
             )
 
         derived_hdwallet = self._copy_hdwallet()
-
         for index in path.lstrip("m/").split("/"):
             if index.endswith("'"):
-                derived_hdwallet = self.derive_from_index(
-                    derived_hdwallet, int(index[:-1]), private=private, hardened=True
+                derived_hdwallet = derived_hdwallet.derive(
+                    int(index[:-1]), private=private, hardened=True
                 )
             else:
-                derived_hdwallet = self.derive_from_index(
-                    derived_hdwallet, int(index), private=private, hardened=False
+                derived_hdwallet = derived_hdwallet.derive(
+                    int(index), private=private, hardened=False
                 )
 
         return derived_hdwallet
 
-    def derive_from_index(
+    def derive(
         self,
-        parent_wallet: HDWallet,
         index: int,
         private: bool = True,
         hardened: bool = False,
     ) -> HDWallet:
         """
-        Derive keys from index.
+        Returns a new HDWallet derived from given index.
 
         Args:
             index: Derivation index.
@@ -301,12 +299,12 @@ class HDWallet:
         Examples:
             >>> mnemonic_words = "test walk nut penalty hip pave soap entry language right filter choice"
             >>> hdwallet = HDWallet.from_mnemonic(mnemonic_words)
-            >>> hdwallet_l1 = hdwallet.derive_from_index(parent_wallet=hdwallet, index=1852, hardened=True)
-            >>> hdwallet_l2 = hdwallet.derive_from_index(parent_wallet=hdwallet_l1, index=1815, hardened=True)
-            >>> hdwallet_l3 = hdwallet.derive_from_index(parent_wallet=hdwallet_l2, index=0, hardened=True)
-            >>> hdwallet_l4 = hdwallet.derive_from_index(parent_wallet=hdwallet_l3, index=0)
-            >>> hdwallet_l5 = hdwallet.derive_from_index(parent_wallet=hdwallet_l4, index=0)
-            >>> hdwallet_l5.public_key.hex()
+            >>> hdwallet = hdwallet.derive(index=1852, hardened=True)
+            >>> hdwallet = hdwallet.derive(index=1815, hardened=True)
+            >>> hdwallet = hdwallet.derive(index=0, hardened=True)
+            >>> hdwallet = hdwallet.derive(index=0)
+            >>> hdwallet = hdwallet.derive(index=0)
+            >>> hdwallet.public_key.hex()
             '73fea80d424276ad0978d4fe5310e8bc2d485f5f6bb3bf87612989f112ad5a7d'
         """
 
@@ -322,19 +320,19 @@ class HDWallet:
         # derive private child key
         if private:
             node = (
-                parent_wallet._xprivate_key[:32],
-                parent_wallet._xprivate_key[32:],
-                parent_wallet._public_key,
-                parent_wallet._chain_code,
-                parent_wallet._path,
+                self._xprivate_key[:32],
+                self._xprivate_key[32:],
+                self._public_key,
+                self._chain_code,
+                self._path,
             )
             derived_hdwallet = self._derive_private_child_key_by_index(node, index)
         # derive public child key
         else:
             node = (
-                parent_wallet._public_key,
-                parent_wallet._chain_code,
-                parent_wallet._path,
+                self._public_key,
+                self._chain_code,
+                self._path,
             )
             derived_hdwallet = self._derive_public_child_key_by_index(node, index)
 
@@ -419,7 +417,12 @@ class HDWallet:
         path += "/" + str(index)
 
         derived_hdwallet = HDWallet(
-            xprivate_key=kL + kR, public_key=A, chain_code=c, path=path
+            xprivate_key=kL + kR,
+            public_key=A,
+            chain_code=c,
+            path=path,
+            root_xprivate_key=self.root_xprivate_key,
+            root_public_key=self.root_public_key,
         )
 
         return derived_hdwallet

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -423,6 +423,7 @@ class HDWallet:
             path=path,
             root_xprivate_key=self.root_xprivate_key,
             root_public_key=self.root_public_key,
+            root_chain_code=self.root_chain_code,
         )
 
         return derived_hdwallet
@@ -481,6 +482,7 @@ class HDWallet:
             path=path,
             root_xprivate_key=self.root_xprivate_key,
             root_public_key=self.root_public_key,
+            root_chain_code=self.root_chain_code,
         )
 
         return derived_hdwallet

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -21,6 +21,18 @@ from pycardano.logging import logger
 __all__ = ["BIP32ED25519PrivateKey", "BIP32ED25519PublicKey", "HDWallet"]
 
 
+SUPPORTED_MNEMONIC_LANGS = {
+    "english",
+    "french",
+    "italian",
+    "japanese",
+    "chinese_simplified",
+    "chinese_traditional",
+    "korean",
+    "spanish",
+}
+
+
 class BIP32ED25519PrivateKey:
     def __init__(self, private_key: bytes, chain_code: bytes):
         self.private_key = private_key
@@ -524,16 +536,7 @@ class HDWallet:
             mnemonic (str): mnemonic words.
         """
 
-        if language and language not in [
-            "english",
-            "french",
-            "italian",
-            "japanese",
-            "chinese_simplified",
-            "chinese_traditional",
-            "korean",
-            "spanish",
-        ]:
+        if language and language not in SUPPORTED_MNEMONIC_LANGS:
             raise ValueError(
                 "invalid language, use only this options english, french, "
                 "italian, spanish, chinese_simplified, chinese_traditional, japanese or korean languages."
@@ -559,16 +562,7 @@ class HDWallet:
             bool. Whether the input mnemonic words is valid.
         """
 
-        if language and language not in [
-            "english",
-            "french",
-            "italian",
-            "japanese",
-            "chinese_simplified",
-            "chinese_traditional",
-            "korean",
-            "spanish",
-        ]:
+        if language and language not in SUPPORTED_MNEMONIC_LANGS:
             raise ValueError(
                 "invalid language, use only this options english, french, "
                 "italian, spanish, chinese_simplified, chinese_traditional, japanese or korean languages."
@@ -576,16 +570,7 @@ class HDWallet:
         try:
             mnemonic = unicodedata.normalize("NFKD", mnemonic)
             if language is None:
-                for _language in [
-                    "english",
-                    "french",
-                    "italian",
-                    "chinese_simplified",
-                    "chinese_traditional",
-                    "japanese",
-                    "korean",
-                    "spanish",
-                ]:
+                for _language in SUPPORTED_MNEMONIC_LANGS:
                     valid = False
                     if Mnemonic(language=_language).check(mnemonic=mnemonic) is True:
                         valid = True

--- a/pycardano/crypto/bip32.py
+++ b/pycardano/crypto/bip32.py
@@ -475,7 +475,13 @@ class HDWallet:
         # compute path
         path += "/" + str(index)
 
-        derived_hdwallet = HDWallet(public_key=A, chain_code=c, path=path)
+        derived_hdwallet = HDWallet(
+            public_key=A,
+            chain_code=c,
+            path=path,
+            root_xprivate_key=self.root_xprivate_key,
+            root_public_key=self.root_public_key,
+        )
 
         return derived_hdwallet
 

--- a/test/pycardano/backend/test_bip32.py
+++ b/test/pycardano/backend/test_bip32.py
@@ -10,6 +10,8 @@ MNEMONIC_15 = "art forum devote street sure rather head chuckle guard poverty re
 MNEMONIC_24 = "excess behave track soul table wear ocean cash stay nature item turtle palm soccer lunch horror start stumble month panic right must lock dress"
 
 MNEMONIC_12_ENTROPY = "df9ed25ed146bf43336a5d7cf7395994"
+MNEMONIC_15_ENTROPY = "0ccb74f36b7da1649a8144675522d4d8097c6412"
+MNEMONIC_24_ENTROPY = "4e828f9a67ddcff0e6391ad4f26ddb7579f59ba14b6dd4baf63dcfdb9d2420da"
 
 
 def test_mnemonic():
@@ -33,6 +35,13 @@ def test_payment_address_12_reward():
             payment_part=None, staking_part=stake_vk.hash(), network=Network.TESTNET
         ).encode()
         == "stake_test1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqp8n5xl"
+    )
+
+    assert (
+        Address(
+            payment_part=None, staking_part=stake_vk.hash(), network=Network.MAINNET
+        ).encode()
+        == "stake1uyevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqxdekzz"
     )
 
 
@@ -63,6 +72,13 @@ def test_payment_address_12_reward2():
         == "stake_test1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqp8n5xl"
     )
 
+    assert (
+        Address(
+            payment_part=None, staking_part=stake_vk.hash(), network=Network.MAINNET
+        ).encode()
+        == "stake1uyevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqxdekzz"
+    )
+
 
 def test_payment_address_12_base():
     hdwallet = HDWallet.from_mnemonic(MNEMONIC_12)
@@ -79,6 +95,11 @@ def test_payment_address_12_base():
         == "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp"
     )
 
+    assert (
+        Address(spend_vk.hash(), stake_vk.hash(), network=Network.MAINNET).encode()
+        == "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqfjkjv7"
+    )
+
 
 def test_payment_address_15_base():
     hdwallet = HDWallet.from_mnemonic(MNEMONIC_15)
@@ -89,6 +110,11 @@ def test_payment_address_15_base():
     hdwallet_stake = hdwallet.derive_from_path("m/1852'/1815'/0'/2/0")
     stake_public_key = hdwallet_stake.public_key
     stake_vk = PaymentVerificationKey.from_primitive(stake_public_key)
+
+    assert (
+        Address(spend_vk.hash(), stake_vk.hash(), network=Network.TESTNET).encode()
+        == "addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w"
+    )
 
     assert (
         Address(spend_vk.hash(), stake_vk.hash(), network=Network.MAINNET).encode()
@@ -105,6 +131,11 @@ def test_payment_address_24_base():
     hdwallet_stake = hdwallet.derive_from_path("m/1852'/1815'/0'/2/0")
     stake_public_key = hdwallet_stake.public_key
     stake_vk = PaymentVerificationKey.from_primitive(stake_public_key)
+
+    assert (
+        Address(spend_vk.hash(), stake_vk.hash(), network=Network.TESTNET).encode()
+        == "addr_test1qqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sw96paj"
+    )
 
     assert (
         Address(spend_vk.hash(), stake_vk.hash(), network=Network.MAINNET).encode()
@@ -125,8 +156,20 @@ def test_payment_address_12_reward_from_entropy():
         == "stake_test1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqp8n5xl"
     )
 
+    assert (
+        Address(
+            payment_part=None, staking_part=stake_vk.hash(), network=Network.MAINNET
+        ).encode()
+        == "stake1uyevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqxdekzz"
+    )
+
 
 def test_is_entropy():
-    entropy = "df9ed25ed146bf43336a5d7cf7395994"
-    is_entropy = HDWallet.is_entropy(entropy)
+    is_entropy = HDWallet.is_entropy(MNEMONIC_12_ENTROPY)
     assert is_entropy
+
+
+def test_is_entropy_wrong_input():
+    wrong_entropy = "df9ed25ed146bf43336a5d7cf73959"
+    is_entropy = HDWallet.is_entropy(wrong_entropy)
+    assert not is_entropy

--- a/test/pycardano/backend/test_bip32.py
+++ b/test/pycardano/backend/test_bip32.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pycardano.address import Address
 from pycardano.crypto.bip32 import HDWallet
 from pycardano.key import PaymentVerificationKey
@@ -108,3 +110,9 @@ def test_payment_address_24_base():
         Address(spend_vk.hash(), stake_vk.hash(), network=Network.MAINNET).encode()
         == "addr1qyy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sdn8p3d"
     )
+
+
+def test_is_entropy():
+    entropy = "df9ed25ed146bf43336a5d7cf7395994"
+    is_entropy = HDWallet.is_entropy(entropy)
+    assert is_entropy

--- a/test/pycardano/backend/test_bip32.py
+++ b/test/pycardano/backend/test_bip32.py
@@ -59,8 +59,8 @@ def test_payment_address_12_reward2():
         .derive(1852, hardened=True)
         .derive(1815, hardened=True)
         .derive(0, hardened=True)
-        .derive(2)
-        .derive(0)
+        .derive(2, private=False)
+        .derive(0, private=False)
     )
     stake_public_key = hdwallet_stake.public_key
     stake_vk = PaymentVerificationKey.from_primitive(stake_public_key)

--- a/test/pycardano/backend/test_bip32.py
+++ b/test/pycardano/backend/test_bip32.py
@@ -1,5 +1,3 @@
-import pytest
-
 from pycardano.address import Address
 from pycardano.crypto.bip32 import HDWallet
 from pycardano.key import PaymentVerificationKey
@@ -10,6 +8,8 @@ from pycardano.network import Network
 MNEMONIC_12 = "test walk nut penalty hip pave soap entry language right filter choice"
 MNEMONIC_15 = "art forum devote street sure rather head chuckle guard poverty release quote oak craft enemy"
 MNEMONIC_24 = "excess behave track soul table wear ocean cash stay nature item turtle palm soccer lunch horror start stumble month panic right must lock dress"
+
+MNEMONIC_12_ENTROPY = "df9ed25ed146bf43336a5d7cf7395994"
 
 
 def test_mnemonic():
@@ -109,6 +109,20 @@ def test_payment_address_24_base():
     assert (
         Address(spend_vk.hash(), stake_vk.hash(), network=Network.MAINNET).encode()
         == "addr1qyy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sdn8p3d"
+    )
+
+
+def test_payment_address_12_reward_from_entropy():
+    hdwallet = HDWallet.from_entropy(MNEMONIC_12_ENTROPY)
+    hdwallet_stake = hdwallet.derive_from_path("m/1852'/1815'/0'/2/0")
+    stake_public_key = hdwallet_stake.public_key
+    stake_vk = PaymentVerificationKey.from_primitive(stake_public_key)
+
+    assert (
+        Address(
+            payment_part=None, staking_part=stake_vk.hash(), network=Network.TESTNET
+        ).encode()
+        == "stake_test1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqp8n5xl"
     )
 
 

--- a/test/pycardano/backend/test_bip32.py
+++ b/test/pycardano/backend/test_bip32.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pycardano.address import Address
 from pycardano.crypto.bip32 import HDWallet
 from pycardano.key import PaymentVerificationKey
@@ -22,6 +24,12 @@ def test_mnemonic():
 def test_mnemonic_generation():
     mnemonic_words = HDWallet.generate_mnemonic(strength=128)
     assert HDWallet.is_mnemonic(mnemonic_words)
+
+
+def test_from_mnemonic_invalid_mnemonic():
+    wrong_mnemonic = "test walk nut penalty hip pave soap entry language right filter"
+    with pytest.raises(ValueError):
+        HDWallet.from_mnemonic(wrong_mnemonic)
 
 
 def test_payment_address_12_reward():
@@ -164,6 +172,11 @@ def test_payment_address_12_reward_from_entropy():
     )
 
 
+def test_from_entropy_invalid_input():
+    with pytest.raises(ValueError):
+        HDWallet.from_entropy("*(#_")
+
+
 def test_is_entropy():
     is_entropy = HDWallet.is_entropy(MNEMONIC_12_ENTROPY)
     assert is_entropy
@@ -173,3 +186,8 @@ def test_is_entropy_wrong_input():
     wrong_entropy = "df9ed25ed146bf43336a5d7cf73959"
     is_entropy = HDWallet.is_entropy(wrong_entropy)
     assert not is_entropy
+
+
+def test_is_entropy_value_error():
+    is_entropy = HDWallet.is_entropy("*(#_")
+    assert is_entropy is False

--- a/test/pycardano/backend/test_bip32.py
+++ b/test/pycardano/backend/test_bip32.py
@@ -54,21 +54,13 @@ def test_payment_address_12_reward():
 
 
 def test_payment_address_12_reward2():
-    hdwallet = HDWallet.from_mnemonic(MNEMONIC_12)
-    hdwalletl_l1 = hdwallet.derive_from_index(
-        hdwallet, 1852, private=True, hardened=True
-    )
-    hdwalletl_l2 = hdwallet.derive_from_index(
-        hdwalletl_l1, 1815, private=True, hardened=True
-    )
-    hdwalletl_l3 = hdwallet.derive_from_index(
-        hdwalletl_l2, 0, private=True, hardened=True
-    )
-    hdwalletl_l4 = hdwallet.derive_from_index(
-        hdwalletl_l3, 2, private=False, hardened=False
-    )
-    hdwallet_stake = hdwallet.derive_from_index(
-        hdwalletl_l4, 0, private=False, hardened=False
+    hdwallet_stake = (
+        HDWallet.from_mnemonic(MNEMONIC_12)
+        .derive(1852, hardened=True)
+        .derive(1815, hardened=True)
+        .derive(0, hardened=True)
+        .derive(2)
+        .derive(0)
     )
     stake_public_key = hdwallet_stake.public_key
     stake_vk = PaymentVerificationKey.from_primitive(stake_public_key)


### PR DESCRIPTION
`mnemonic` Python package generates an entropy value in `bytearray` type.
However, `HDWallet.entropy` class is expecting a string value and it is used as a string throughout the entire bip32.py module codebase.

This merge request explicitly converts generated entropy value as a string value to be consistent with the original implementer's intention.