### PR TITLE
Update variable name so it matches downstream code

### DIFF
--- a/docs/source/guides/transaction.rst
+++ b/docs/source/guides/transaction.rst
@@ -148,9 +148,9 @@ with its `build_and_sign` method. The code below tells the builder to build a tr
 with a list of signing keys (in this case, we only need the signature from one signing key, `sk`) and send the change
 back to sender's address::
 
-    >>> tx = builder.build_and_sign([sk], change_address=address)
+    >>> signed_tx = builder.build_and_sign([sk], change_address=address)
 
-Transaction ID could be obtained from the transaction obejct::
+Transaction ID could be obtained from the transaction object::
 
     >>> tx.id
     TransactionId(hex='1d40b950ded3a144fb4c100d1cf8b85719da91b06845530e34a0304427692ce4')


### PR DESCRIPTION
Documentation correction: Line 172 requires a `signed_tx` variable but it's only defined as `tx` on line 151 resulting in an error.