### PR TITLE
Attempt to improve liskov substitution principle error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ exclude = [
     '^pycardano/logging.py$',
     '^pycardano/metadata.py$',
     '^pycardano/nativescript.py$',
-    '^pycardano/network.py$',
     '^pycardano/plutus.py$',
     '^pycardano/serialization.py$',
     '^pycardano/transaction.py$',


### PR DESCRIPTION
# Background
* Subclasses of `CBORSerializable` tend to override primitive related methods with tighter and specific parameter and return value types.
* Mypy raises the same error for most of the `CBORSerializable` subclasses and `network.py` module is the smallest module demonstrating the problem.
* According to Liskov Principle, subclasses should have looser type requirements rather than having tighter type requirements:
    * https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
    * https://stackoverflow.com/questions/56860/what-is-an-example-of-the-liskov-substitution-principle

# Goal
* Start a discussion in an attempt to improve PyCardano code quality
* I would love to hear your opinion on this, @cffls.

```
$ make qa
poetry run flake8 pycardano
poetry run mypy --install-types --non-interactive pycardano
pycardano/network.py:21: error: Return type "int" of "to_primitive" incompatible with return type "Primitive" in supertype "CBORSerializable"
pycardano/network.py:25: error: Argument 1 of "from_primitive" is incompatible with supertype "CBORSerializable"; supertype defines the argument type as "Primitive"
pycardano/network.py:25: note: This violates the Liskov substitution principle
pycardano/network.py:25: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
Found 2 errors in 1 file (checked 10 source files)
make: *** [Makefile:65: qa] Error 1

```