### PR TITLE
Improve address type hint

### DIFF
--- a/pycardano/address.py
+++ b/pycardano/address.py
@@ -19,7 +19,7 @@ from pycardano.exception import (
 )
 from pycardano.hash import VERIFICATION_KEY_HASH_SIZE, ScriptHash, VerificationKeyHash
 from pycardano.network import Network
-from pycardano.serialization import CBORSerializable
+from pycardano.serialization import CBORSerializable, Primitive
 
 __all__ = ["AddressType", "PointerAddress", "Address"]
 
@@ -160,7 +160,11 @@ class PointerAddress(CBORSerializable):
         return self.encode()
 
     @classmethod
-    def from_primitive(cls: Type[PointerAddress], value: bytes) -> PointerAddress:
+    def from_primitive(cls: Type[PointerAddress], value: Primitive) -> PointerAddress:
+        if not isinstance(value, bytes):
+            raise DeserializeException(
+                f"A bytes value is required for deserialization: {value}"
+            )
         return cls.decode(value)
 
     def __eq__(self, other):

--- a/pycardano/address.py
+++ b/pycardano/address.py
@@ -343,7 +343,18 @@ class Address(CBORSerializable):
         return bytes(self)
 
     @classmethod
-    def from_primitive(cls: Type[Address], value: Union[bytes, str]) -> Address:
+    def from_primitive(cls: Type[Address], value: Primitive) -> Address:
+        if not isinstance(
+            value,
+            (
+                bytes,
+                str,
+            ),
+        ):
+            raise DeserializeException(
+                f"A bytes or a string value is required for deserialization: {value}"
+            )
+
         if isinstance(value, str):
             value = bytes(decode(value))
         header = value[0]

--- a/pycardano/address.py
+++ b/pycardano/address.py
@@ -19,7 +19,7 @@ from pycardano.exception import (
 )
 from pycardano.hash import VERIFICATION_KEY_HASH_SIZE, ScriptHash, VerificationKeyHash
 from pycardano.network import Network
-from pycardano.serialization import CBORSerializable, Primitive
+from pycardano.serialization import CBORSerializable, limit_primitive_type
 
 __all__ = ["AddressType", "PointerAddress", "Address"]
 
@@ -160,11 +160,8 @@ class PointerAddress(CBORSerializable):
         return self.encode()
 
     @classmethod
-    def from_primitive(cls: Type[PointerAddress], value: Primitive) -> PointerAddress:
-        if not isinstance(value, bytes):
-            raise DeserializeException(
-                f"A bytes value is required for deserialization: {value}"
-            )
+    @limit_primitive_type(bytes)
+    def from_primitive(cls: Type[PointerAddress], value: bytes) -> PointerAddress:
         return cls.decode(value)
 
     def __eq__(self, other):
@@ -343,18 +340,8 @@ class Address(CBORSerializable):
         return bytes(self)
 
     @classmethod
-    def from_primitive(cls: Type[Address], value: Primitive) -> Address:
-        if not isinstance(
-            value,
-            (
-                bytes,
-                str,
-            ),
-        ):
-            raise DeserializeException(
-                f"A bytes or a string value is required for deserialization: {value}"
-            )
-
+    @limit_primitive_type(bytes, str)
+    def from_primitive(cls: Type[Address], value: Union[bytes, str]) -> Address:
         if isinstance(value, str):
             value = bytes(decode(value))
         header = value[0]

--- a/pycardano/hash.py
+++ b/pycardano/hash.py
@@ -2,7 +2,7 @@
 
 from typing import Type, TypeVar, Union
 
-from pycardano.serialization import CBORSerializable
+from pycardano.serialization import CBORSerializable, limit_primitive_type
 
 __all__ = [
     "VERIFICATION_KEY_HASH_SIZE",
@@ -67,6 +67,7 @@ class ConstrainedBytes(CBORSerializable):
         return self.payload
 
     @classmethod
+    @limit_primitive_type(bytes, str)
     def from_primitive(cls: Type[T], value: Union[bytes, str]) -> T:
         if isinstance(value, str):
             value = bytes.fromhex(value)

--- a/pycardano/key.py
+++ b/pycardano/key.py
@@ -14,7 +14,7 @@ from nacl.signing import SigningKey as NACLSigningKey
 from pycardano.crypto.bip32 import BIP32ED25519PrivateKey, HDWallet
 from pycardano.exception import InvalidKeyTypeException
 from pycardano.hash import VERIFICATION_KEY_HASH_SIZE, VerificationKeyHash
-from pycardano.serialization import CBORSerializable
+from pycardano.serialization import CBORSerializable, limit_primitive_type
 
 __all__ = [
     "Key",
@@ -62,6 +62,7 @@ class Key(CBORSerializable):
         return self.payload
 
     @classmethod
+    @limit_primitive_type(bytes)
     def from_primitive(cls: Type["Key"], value: bytes) -> Key:
         return cls(value)
 

--- a/pycardano/metadata.py
+++ b/pycardano/metadata.py
@@ -16,6 +16,7 @@ from pycardano.serialization import (
     DictCBORSerializable,
     MapCBORSerializable,
     Primitive,
+    limit_primitive_type,
     list_hook,
 )
 
@@ -91,6 +92,7 @@ class AlonzoMetadata(MapCBORSerializable):
         return CBORTag(AlonzoMetadata.TAG, super(AlonzoMetadata, self).to_primitive())
 
     @classmethod
+    @limit_primitive_type(CBORTag)
     def from_primitive(cls: Type[AlonzoMetadata], value: CBORTag) -> AlonzoMetadata:
         if not hasattr(value, "tag"):
             raise DeserializeException(

--- a/pycardano/nativescript.py
+++ b/pycardano/nativescript.py
@@ -10,7 +10,12 @@ from nacl.hash import blake2b
 
 from pycardano.exception import DeserializeException
 from pycardano.hash import SCRIPT_HASH_SIZE, ScriptHash, VerificationKeyHash
-from pycardano.serialization import ArrayCBORSerializable, Primitive, list_hook
+from pycardano.serialization import (
+    ArrayCBORSerializable,
+    Primitive,
+    limit_primitive_type,
+    list_hook,
+)
 from pycardano.types import JsonDict
 
 __all__ = [
@@ -30,22 +35,12 @@ class NativeScript(ArrayCBORSerializable):
     json_field: ClassVar[str]
 
     @classmethod
+    @limit_primitive_type(list)
     def from_primitive(
-        cls: Type[NativeScript], value: Primitive
+        cls: Type[NativeScript], value: list
     ) -> Union[
         ScriptPubkey, ScriptAll, ScriptAny, ScriptNofK, InvalidBefore, InvalidHereAfter
     ]:
-        if not isinstance(
-            value,
-            (
-                list,
-                tuple,
-            ),
-        ):
-            raise DeserializeException(
-                f"A list or a tuple is required for deserialization: {value}"
-            )
-
         script_type: int = value[0]
         if script_type == ScriptPubkey._TYPE:
             return super(NativeScript, ScriptPubkey).from_primitive(value[1:])

--- a/pycardano/nativescript.py
+++ b/pycardano/nativescript.py
@@ -43,7 +43,7 @@ class NativeScript(ArrayCBORSerializable):
             ),
         ):
             raise DeserializeException(
-                f"A list or a tuple is required for deserialization: {str(value)}"
+                f"A list or a tuple is required for deserialization: {value}"
             )
 
         script_type: int = value[0]

--- a/pycardano/network.py
+++ b/pycardano/network.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Type
 
-from pycardano.exception import DeserializeException
-from pycardano.serialization import CBORSerializable, Primitive
+from pycardano.serialization import CBORSerializable, limit_primitive_type
 
 __all__ = ["Network"]
 
@@ -23,9 +22,6 @@ class Network(CBORSerializable, Enum):
         return self.value
 
     @classmethod
-    def from_primitive(cls: Type[Network], value: Primitive) -> Network:
-        if not isinstance(value, int):
-            raise DeserializeException(
-                f"An integer value is required for deserialization: {value}"
-            )
+    @limit_primitive_type(int)
+    def from_primitive(cls: Type[Network], value: int) -> Network:
         return cls(value)

--- a/pycardano/network.py
+++ b/pycardano/network.py
@@ -26,6 +26,6 @@ class Network(CBORSerializable, Enum):
     def from_primitive(cls: Type[Network], value: Primitive) -> Network:
         if not isinstance(value, int):
             raise DeserializeException(
-                f"An integer value is required for deserialization: {str(value)}"
+                f"An integer value is required for deserialization: {value}"
             )
         return cls(value)

--- a/pycardano/plutus.py
+++ b/pycardano/plutus.py
@@ -6,7 +6,7 @@ import inspect
 import json
 from dataclasses import dataclass, field, fields
 from enum import Enum
-from typing import Any, ClassVar, List, Optional, Type, Union
+from typing import Any, ClassVar, Optional, Type, Union
 
 import cbor2
 from cbor2 import CBORTag
@@ -21,9 +21,9 @@ from pycardano.serialization import (
     CBORSerializable,
     DictCBORSerializable,
     IndefiniteList,
-    Primitive,
     RawCBOR,
     default_encoder,
+    limit_primitive_type,
 )
 
 __all__ = [
@@ -66,6 +66,7 @@ class CostModels(DictCBORSerializable):
         return result
 
     @classmethod
+    @limit_primitive_type(dict)
     def from_primitive(cls: Type[CostModels], value: dict) -> CostModels:
         raise DeserializeException(
             "Deserialization of cost model is impossible, because some information is lost "
@@ -480,11 +481,8 @@ class PlutusData(ArrayCBORSerializable):
             return CBORTag(102, [self.CONSTR_ID, primitives])
 
     @classmethod
+    @limit_primitive_type(CBORTag)
     def from_primitive(cls: Type[PlutusData], value: CBORTag) -> PlutusData:
-        if not isinstance(value, CBORTag):
-            raise DeserializeException(
-                f"Unexpected type: {CBORTag}. Got {type(value)} instead."
-            )
         if value.tag == 102:
             tag = value.value[0]
             if tag != cls.CONSTR_ID:
@@ -643,6 +641,7 @@ class RawPlutusData(CBORSerializable):
         return _dfs(self.data)
 
     @classmethod
+    @limit_primitive_type(CBORTag)
     def from_primitive(cls: Type[RawPlutusData], value: CBORTag) -> RawPlutusData:
         return cls(value)
 
@@ -675,6 +674,7 @@ class RedeemerTag(CBORSerializable, Enum):
         return self.value
 
     @classmethod
+    @limit_primitive_type(int)
     def from_primitive(cls: Type[RedeemerTag], value: int) -> RedeemerTag:
         return cls(value)
 
@@ -704,7 +704,8 @@ class Redeemer(ArrayCBORSerializable):
     ex_units: ExecutionUnits = None
 
     @classmethod
-    def from_primitive(cls: Type[Redeemer], values: List[Primitive]) -> Redeemer:
+    @limit_primitive_type(list)
+    def from_primitive(cls: Type[Redeemer], values: list) -> Redeemer:
         if isinstance(values[2], CBORTag) and cls is Redeemer:
             values[2] = RawPlutusData.from_primitive(values[2])
         redeemer = super(Redeemer, cls).from_primitive(

--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -407,7 +407,7 @@ def _restore_dataclass_field(
             elif t in PRIMITIVE_TYPES and isinstance(v, t):
                 return v
         raise DeserializeException(
-            f"Cannot deserialize object: \n{str(v)}\n in any valid type from {t_args}."
+            f"Cannot deserialize object: \n{v}\n in any valid type from {t_args}."
         )
     return v
 
@@ -739,10 +739,10 @@ class DictCBORSerializable(CBORSerializable):
             DeserializeException: When the object could not be restored from primitives.
         """
         if not value:
-            raise DeserializeException(f"Cannot accept empty value {str(value)}.")
+            raise DeserializeException(f"Cannot accept empty value {value}.")
         if not isinstance(value, dict):
             raise DeserializeException(
-                f"A dictionary value is required for deserialization: {str(value)}"
+                f"A dictionary value is required for deserialization: {value}"
             )
 
         restored = cls()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ python_version = 3.7
 exclude = [
     '^pycardano/cip/cip8.py$',
     '^pycardano/crypto/bech32.py$',
-    '^pycardano/address.py$',
     '^pycardano/certificate.py$',
     '^pycardano/coinselection.py$',
     '^pycardano/exception.py$',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ profile = "black"
 
 [tool.mypy]
 ignore_missing_imports = true
+disable_error_code = ["str-bytes-safe"]
 python_version = 3.7
 exclude = [
     '^pycardano/cip/cip8.py$',

--- a/test/pycardano/test_address.py
+++ b/test/pycardano/test_address.py
@@ -1,4 +1,7 @@
-from pycardano.address import Address
+from unittest import TestCase
+
+from pycardano.address import Address, PointerAddress
+from pycardano.exception import DeserializeException
 from pycardano.key import PaymentVerificationKey
 from pycardano.network import Network
 
@@ -15,3 +18,9 @@ def test_payment_addr():
         Address(vk.hash(), network=Network.TESTNET).encode()
         == "addr_test1vr2p8st5t5cxqglyjky7vk98k7jtfhdpvhl4e97cezuhn0cqcexl7"
     )
+
+
+class PointerAddressTest(TestCase):
+    def test_from_primitive_invalid_value(self):
+        with self.assertRaises(DeserializeException):
+            PointerAddress.from_primitive(1)

--- a/test/pycardano/test_address.py
+++ b/test/pycardano/test_address.py
@@ -24,3 +24,21 @@ class PointerAddressTest(TestCase):
     def test_from_primitive_invalid_value(self):
         with self.assertRaises(DeserializeException):
             PointerAddress.from_primitive(1)
+
+        with self.assertRaises(DeserializeException):
+            PointerAddress.from_primitive([])
+
+        with self.assertRaises(DeserializeException):
+            PointerAddress.from_primitive({})
+
+
+class AddressTest(TestCase):
+    def test_from_primitive_invalid_value(self):
+        with self.assertRaises(DeserializeException):
+            Address.from_primitive(1)
+
+        with self.assertRaises(DeserializeException):
+            Address.from_primitive([])
+
+        with self.assertRaises(DeserializeException):
+            Address.from_primitive({})

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1,11 +1,38 @@
 from dataclasses import dataclass, field
 from test.pycardano.util import check_two_way_cbor
 
+import pytest
+
+from pycardano.exception import DeserializeException
 from pycardano.serialization import (
     ArrayCBORSerializable,
+    CBORSerializable,
     DictCBORSerializable,
     MapCBORSerializable,
+    limit_primitive_type,
 )
+
+
+@pytest.mark.single
+def test_limit_primitive_type():
+    class MockClass(CBORSerializable):
+        @classmethod
+        def from_primitive(*args):
+            return
+
+    wrapped = limit_primitive_type(int, str, bytes, list, dict, tuple, dict)(
+        MockClass.from_primitive
+    )
+    wrapped(MockClass, 1)
+    wrapped(MockClass, "")
+    wrapped(MockClass, b"")
+    wrapped(MockClass, [])
+    wrapped(MockClass, tuple())
+    wrapped(MockClass, {})
+
+    wrapped = limit_primitive_type(int)(MockClass.from_primitive)
+    with pytest.raises(DeserializeException):
+        wrapped(MockClass, "")
 
 
 def test_array_cbor_serializable():


### PR DESCRIPTION
# Goal:
* Improve address.py module's type hint related code quality

```
$ make qa
poetry run flake8 pycardano
poetry run mypy --install-types --non-interactive pycardano
pycardano/address.py:154: error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
pycardano/address.py:163: error: Argument 1 of "from_primitive" is incompatible with supertype "CBORSerializable"; supertype defines the argument type as "Union[bytes, bytearray, str, int, float, Decimal, bool, None, Tuple[Any, ...], List[Any], IndefiniteList, Dict[Any, Any], defaultdict[Any, Any], OrderedDict[Any, Any], Any, datetime, Pattern[Any], Any, Any, Set[Any], FrozenSet[Any]]"  [override]
pycardano/address.py:163: note: This violates the Liskov substitution principle
pycardano/address.py:163: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
pycardano/address.py:342: error: Argument 1 of "from_primitive" is incompatible with supertype "CBORSerializable"; supertype defines the argument type as "Union[bytes, bytearray, str, int, float, Decimal, bool, None, Tuple[Any, ...], List[Any], IndefiniteList, Dict[Any, Any], defaultdict[Any, Any], OrderedDict[Any, Any], Any, datetime, Pattern[Any], Any, Any, Set[Any], FrozenSet[Any]]"  [override]
pycardano/address.py:342: note: This violates the Liskov substitution principle
pycardano/address.py:342: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
pycardano/address.py:393: error: On Python 3 formatting "b'abc'" with "{}" produces "b'abc'", not "abc"; use "{!r}" if this is desired behavior  [str-bytes-safe]
Found 4 errors in 1 file (checked 13 source files)

```