### PR TITLE
Move execution unit estimation to the very last part of tx building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
-        exclude:
-          # excludes python 3.11 on macOS
-          - os: macos-latest
-            python-version: '3.11'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'

--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -568,7 +568,7 @@ class MapCBORSerializable(CBORSerializable):
 
         Basic usage:
 
-        >>> from dataclasses import dataclass
+        >>> from dataclasses import dataclass, field
         >>> @dataclass
         ... class Test1(MapCBORSerializable):
         ...     a: str=""
@@ -576,7 +576,7 @@ class MapCBORSerializable(CBORSerializable):
         >>> @dataclass
         ... class Test2(MapCBORSerializable):
         ...     c: str=None
-        ...     test1: Test1=Test1()
+        ...     test1: Test1=field(default_factory=Test1)
         >>> t = Test2(test1=Test1(a="a"))
         >>> t
         Test2(c=None, test1=Test1(a='a', b=''))
@@ -600,7 +600,7 @@ class MapCBORSerializable(CBORSerializable):
         >>> @dataclass
         ... class Test2(MapCBORSerializable):
         ...     c: str=field(default=None, metadata={"key": "0", "optional": True})
-        ...     test1: Test1=field(default=Test1(), metadata={"key": "1"})
+        ...     test1: Test1=field(default_factory=Test1, metadata={"key": "1"})
         >>> t = Test2(test1=Test1(a="a"))
         >>> t
         Test2(c=None, test1=Test1(a='a', b=''))

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -87,7 +87,7 @@ def test_map_cbor_serializable():
     @dataclass
     class Test2(MapCBORSerializable):
         c: str = None
-        test1: Test1 = Test1()
+        test1: Test1 = field(default_factory=Test1)
 
     t = Test2(test1=Test1(a="a"))
     assert t.to_cbor() == "a26163f6657465737431a261616161616260"
@@ -103,7 +103,7 @@ def test_map_cbor_serializable_custom_keys():
     @dataclass
     class Test2(MapCBORSerializable):
         c: str = field(default=None, metadata={"key": "0", "optional": True})
-        test1: Test1 = field(default=Test1(), metadata={"key": "1"})
+        test1: Test1 = field(default_factory=Test1, metadata={"key": "1"})
 
     t = Test2(test1=Test1(a="a"))
     assert t.to_primitive() == {"1": {"0": "a", "1": ""}}


### PR DESCRIPTION
Redeemer index will change during txbuilding. If execution unit estimation is performed before the final redeemer index is finalized, there could be mismatch between the index returned from estimation and the index stored locally in txbuilder.