### PR TITLE
Add functions to automatically add required signers and validity range

### DIFF
--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -898,8 +898,8 @@ class TransactionBuilder:
 
         if auto_required_signers:
             # collect all signatories from explicitly defined transaction inputs and collateral inputs
-            required_signers = set(i.output.address.payment_part for i in self.inputs + self.collaterals)
-            self.required_signers = required_signers
+            required_signers = set(i.output.address.payment_part for i in self.inputs + self.collaterals if not isinstance(i.output.address.payment_part, ScriptHash))
+            self.required_signers = list(required_signers)
 
         selected_utxos = []
         selected_amount = Value()

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -880,8 +880,10 @@ class TransactionBuilder:
             merge_change (Optional[bool]): If the change address match one of the transaction output, the change amount
                 will be directly added to that transaction output, instead of being added as a separate output.
             collateral_change_address (Optional[Address]): Address to which collateral changes will be returned.
-            auto_validity (Optional[bool]): Automatically set the validity interval of the transaction to a reasonable value
-            auto_required_signers (Optional[bool]): Automatically add all pubkeyhashes of transaction inputs to required signatories
+            auto_validity (Optional[bool]): Automatically set the validity interval of the transaction to a
+                reasonable value
+            auto_required_signers (Optional[bool]): Automatically add all pubkeyhashes of transaction inputs
+                to required signatories
 
         Returns:
             TransactionBody: A transaction body.
@@ -902,6 +904,7 @@ class TransactionBuilder:
                 i.output.address.payment_part
                 for i in self.inputs + self.collaterals
                 if not isinstance(i.output.address.payment_part, ScriptHash)
+                and i.output.address.payment_part is not None
             )
             self.required_signers = list(required_signers)
 
@@ -1201,8 +1204,10 @@ class TransactionBuilder:
             merge_change (Optional[bool]): If the change address match one of the transaction output, the change amount
                 will be directly added to that transaction output, instead of being added as a separate output.
             collateral_change_address (Optional[Address]): Address to which collateral changes will be returned.
-            auto_validity (Optional[bool]): Automatically set the validity interval of the transaction to a reasonable value
-            auto_required_signers (Optional[bool]): Automatically add all pubkeyhashes of transaction inputs to required signatories
+            auto_validity (Optional[bool]): Automatically set the validity interval of the transaction to
+                a reasonable value
+            auto_required_signers (Optional[bool]): Automatically add all pubkeyhashes of transaction inputs
+                to required signatories
 
         Returns:
             Transaction: A signed transaction.

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -916,14 +916,6 @@ class TransactionBuilder:
                 auto_ttl_offset = 10_000
             self.ttl = max(0, last_slot + auto_ttl_offset)
 
-        # Automatically set the required signers for smart transactions
-        if (
-            is_smart and auto_required_signers is not False
-        ) and self.required_signers is None:
-            # Collect all signatories from explicitly defined
-            # transaction inputs and collateral inputs, and input addresses
-            self.required_signers = list(self._input_vkey_hashes())
-
         selected_utxos = []
         selected_amount = Value()
         for i in self.inputs:
@@ -1054,6 +1046,14 @@ class TransactionBuilder:
         )
 
         self.inputs[:] = selected_utxos[:]
+
+        # Automatically set the required signers for smart transactions
+        if (
+            is_smart and auto_required_signers is not False
+        ) and self.required_signers is None:
+            # Collect all signatories from explicitly defined
+            # transaction inputs and collateral inputs, and input addresses
+            self.required_signers = list(self._input_vkey_hashes())
 
         self._set_redeemer_index()
 

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -869,8 +869,8 @@ class TransactionBuilder:
         change_address: Optional[Address] = None,
         merge_change: Optional[bool] = False,
         collateral_change_address: Optional[Address] = None,
-        auto_validity = True,
-        auto_required_signers=True,
+        auto_validity: Optional[bool] = True,
+        auto_required_signers: Optional[bool] = True,
     ) -> TransactionBody:
         """Build a transaction body from all constraints set through the builder.
 
@@ -1183,6 +1183,8 @@ class TransactionBuilder:
         change_address: Optional[Address] = None,
         merge_change: Optional[bool] = False,
         collateral_change_address: Optional[Address] = None,
+        auto_validity: Optional[bool] = True,
+        auto_required_signers: Optional[bool] = True,
     ) -> Transaction:
         """Build a transaction body from all constraints set through the builder and sign the transaction with
         provided signing keys.
@@ -1195,6 +1197,8 @@ class TransactionBuilder:
             merge_change (Optional[bool]): If the change address match one of the transaction output, the change amount
                 will be directly added to that transaction output, instead of being added as a separate output.
             collateral_change_address (Optional[Address]): Address to which collateral changes will be returned.
+            auto_validity (Optional[bool]): Automatically set the validity interval of the transaction to a reasonable value
+            auto_required_signers (Optional[bool]): Automatically add all pubkeyhashes of transaction inputs to required signatories
 
         Returns:
             Transaction: A signed transaction.
@@ -1204,6 +1208,8 @@ class TransactionBuilder:
             change_address=change_address,
             merge_change=merge_change,
             collateral_change_address=collateral_change_address,
+            auto_validity=auto_validity,
+            auto_required_signers=auto_required_signers,
         )
         witness_set = self.build_witness_set()
         witness_set.vkey_witnesses = []

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -924,7 +924,10 @@ class TransactionBuilder:
             # transaction inputs and collateral inputs, and input addresses
             input_addresses = [
                 i.output.address for i in self.inputs + self.collaterals
-            ] + [Address.from_primitive(a) for a in self.input_addresses]
+            ] + [
+                Address.from_primitive(a) if isinstance(a, str) else a
+                for a in self.input_addresses
+            ]
             required_signers = set(
                 a.payment_part
                 for a in input_addresses

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -898,7 +898,11 @@ class TransactionBuilder:
 
         if auto_required_signers:
             # collect all signatories from explicitly defined transaction inputs and collateral inputs
-            required_signers = set(i.output.address.payment_part for i in self.inputs + self.collaterals if not isinstance(i.output.address.payment_part, ScriptHash))
+            required_signers = set(
+                i.output.address.payment_part
+                for i in self.inputs + self.collaterals
+                if not isinstance(i.output.address.payment_part, ScriptHash)
+            )
             self.required_signers = list(required_signers)
 
         selected_utxos = []

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -918,7 +918,7 @@ class TransactionBuilder:
 
         # Automatically set the required signers for smart transactions
         if (
-            is_smart or auto_required_signers is not None
+            is_smart and auto_required_signers is not False
         ) and self.required_signers is None:
             # Collect all signatories from explicitly defined
             # transaction inputs and collateral inputs, and input addresses

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -923,8 +923,6 @@ class TransactionBuilder:
             # Collect all signatories from explicitly defined
             # transaction inputs and collateral inputs, and input addresses
             input_addresses = [
-                i.output.address for i in self.inputs + self.collaterals
-            ] + [
                 Address.from_primitive(a) if isinstance(a, str) else a
                 for a in self.input_addresses
             ]
@@ -932,7 +930,7 @@ class TransactionBuilder:
                 a.payment_part
                 for a in input_addresses
                 if isinstance(a.payment_part, VerificationKeyHash)
-            )
+            ) | self._input_vkey_hashes()
             self.required_signers = list(required_signers)
 
         selected_utxos = []

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -926,11 +926,11 @@ class TransactionBuilder:
                 Address.from_primitive(a) if isinstance(a, str) else a
                 for a in self.input_addresses
             ]
-            required_signers = set(
+            required_signers = self._input_vkey_hashes() | set(
                 a.payment_part
                 for a in input_addresses
                 if isinstance(a.payment_part, VerificationKeyHash)
-            ) | self._input_vkey_hashes()
+            )
             self.required_signers = list(required_signers)
 
         selected_utxos = []

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -894,7 +894,7 @@ class TransactionBuilder:
             # Automatically set the validity range to a tight value around transaction creation
             last_slot = self.context.last_block_slot
             if self.validity_start is None:
-                self.validity_start = last_slot - 1000
+                self.validity_start = max(0, last_slot - 1000)
             if self.ttl is None:
                 self.ttl = last_slot + 10000
 

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -922,16 +922,7 @@ class TransactionBuilder:
         ) and self.required_signers is None:
             # Collect all signatories from explicitly defined
             # transaction inputs and collateral inputs, and input addresses
-            input_addresses = [
-                Address.from_primitive(a) if isinstance(a, str) else a
-                for a in self.input_addresses
-            ]
-            required_signers = self._input_vkey_hashes() | set(
-                a.payment_part
-                for a in input_addresses
-                if isinstance(a.payment_part, VerificationKeyHash)
-            )
-            self.required_signers = list(required_signers)
+            self.required_signers = list(self._input_vkey_hashes())
 
         selected_utxos = []
         selected_amount = Value()

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -59,7 +59,9 @@ def test_tx_builder(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -100,7 +102,9 @@ def test_tx_builder_with_certain_input(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [[b"22222222222222222222222222222222", 1]],
@@ -136,7 +140,9 @@ def test_tx_builder_multi_asset(chain_context):
         )
     )
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [
@@ -178,7 +184,11 @@ def test_tx_builder_raises_utxo_selection(chain_context):
     )
 
     with pytest.raises(UTxOSelectionException) as e:
-        tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+        tx_body = tx_builder.build(
+            change_address=sender_address,
+            auto_validity=False,
+            auto_required_signers=False,
+        )
 
     # The unfulfilled amount includes requested (991000000) and estimated fees (161277)
     assert "Unfulfilled amount:\n {\n  'coin': 991161277" in e.value.args[0]
@@ -214,7 +224,9 @@ def test_tx_small_utxo_precise_fee(chain_context):
 
     # This will not fail as we replace max fee constraint with more precise fee calculation
     # And remainder is greater than minimum ada required for change
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expect = {
         0: [
@@ -266,7 +278,9 @@ def test_tx_small_utxo_balance_pass(chain_context):
 
     # Balance is smaller than minimum ada required in change
     # Additional UTxOs are selected from the input address
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [
@@ -312,7 +326,9 @@ def test_tx_builder_mint_multi_asset(chain_context):
     tx_builder.native_scripts = [script]
     tx_builder.ttl = 123456789
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [
@@ -354,7 +370,9 @@ def test_tx_add_change_split_nfts(chain_context):
         TransactionOutput.from_primitive([sender, 7000000])
     )
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [
@@ -786,7 +804,9 @@ def test_excluded_input(chain_context):
 
     tx_builder.excluded_inputs.append(chain_context.utxos(sender)[0])
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [[b"22222222222222222222222222222222", 1]],
@@ -819,7 +839,9 @@ def test_build_and_sign(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder1.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder1.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     tx_builder2 = TransactionBuilder(
         chain_context, [RandomImproveMultiAsset([0, 0, 0, 0, 0])]
@@ -827,7 +849,12 @@ def test_build_and_sign(chain_context):
     tx_builder2.add_input_address(sender).add_output(
         TransactionOutput.from_primitive([sender, 500000])
     )
-    tx = tx_builder2.build_and_sign([SK], change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx = tx_builder2.build_and_sign(
+        [SK],
+        change_address=sender_address,
+        auto_validity=False,
+        auto_required_signers=False,
+    )
 
     assert tx.transaction_witness_set.vkey_witnesses == [
         VerificationKeyWitness(SK.to_verification_key(), SK.sign(tx_body.hash()))
@@ -897,7 +924,9 @@ def test_tx_builder_exact_fee_no_change(chain_context):
         TransactionOutput.from_primitive([sender, input_amount - tx_body.fee])
     )
 
-    tx = tx_builder.build_and_sign([SK], auto_validity=False, auto_required_signers=False)
+    tx = tx_builder.build_and_sign(
+        [SK], auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -933,7 +962,9 @@ def test_tx_builder_certificates(chain_context):
 
     tx_builder.certificates = [stake_registration, stake_delegation]
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -970,7 +1001,9 @@ def test_tx_builder_withdrawal(chain_context):
     withdrawals = Withdrawals({bytes(stake_address): 10000})
     tx_builder.withdrawals = withdrawals
 
-    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address, auto_validity=False, auto_required_signers=False
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -1002,7 +1035,12 @@ def test_tx_builder_no_output(chain_context):
 
     tx_builder.add_input(utxo1)
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address,
+        merge_change=True,
+        auto_validity=False,
+        auto_required_signers=False,
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1029,7 +1067,12 @@ def test_tx_builder_merge_change_to_output(chain_context):
     tx_builder.add_input(utxo1)
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 10000]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address,
+        merge_change=True,
+        auto_validity=False,
+        auto_required_signers=False,
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1060,7 +1103,12 @@ def test_tx_builder_merge_change_to_output_2(chain_context):
     tx_builder.add_output(TransactionOutput.from_primitive([receiver, 10000]))
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 0]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address,
+        merge_change=True,
+        auto_validity=False,
+        auto_required_signers=False,
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1089,7 +1137,12 @@ def test_tx_builder_merge_change_to_zero_amount_output(chain_context):
     tx_builder.add_input(utxo1)
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 0]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address,
+        merge_change=True,
+        auto_validity=False,
+        auto_required_signers=False,
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1116,7 +1169,12 @@ def test_tx_builder_merge_change_smaller_than_min_utxo(chain_context):
     tx_builder.add_input(utxo1)
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 9800000]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build(
+        change_address=sender_address,
+        merge_change=True,
+        auto_validity=False,
+        auto_required_signers=False,
+    )
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -59,7 +59,7 @@ def test_tx_builder(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -100,7 +100,7 @@ def test_tx_builder_with_certain_input(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"22222222222222222222222222222222", 1]],
@@ -136,7 +136,7 @@ def test_tx_builder_multi_asset(chain_context):
         )
     )
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [
@@ -178,7 +178,7 @@ def test_tx_builder_raises_utxo_selection(chain_context):
     )
 
     with pytest.raises(UTxOSelectionException) as e:
-        tx_body = tx_builder.build(change_address=sender_address)
+        tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     # The unfulfilled amount includes requested (991000000) and estimated fees (161277)
     assert "Unfulfilled amount:\n {\n  'coin': 991161277" in e.value.args[0]
@@ -214,7 +214,7 @@ def test_tx_small_utxo_precise_fee(chain_context):
 
     # This will not fail as we replace max fee constraint with more precise fee calculation
     # And remainder is greater than minimum ada required for change
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expect = {
         0: [
@@ -266,7 +266,7 @@ def test_tx_small_utxo_balance_pass(chain_context):
 
     # Balance is smaller than minimum ada required in change
     # Additional UTxOs are selected from the input address
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [
@@ -312,7 +312,7 @@ def test_tx_builder_mint_multi_asset(chain_context):
     tx_builder.native_scripts = [script]
     tx_builder.ttl = 123456789
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [
@@ -354,7 +354,7 @@ def test_tx_add_change_split_nfts(chain_context):
         TransactionOutput.from_primitive([sender, 7000000])
     )
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [
@@ -786,7 +786,7 @@ def test_excluded_input(chain_context):
 
     tx_builder.excluded_inputs.append(chain_context.utxos(sender)[0])
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"22222222222222222222222222222222", 1]],
@@ -819,7 +819,7 @@ def test_build_and_sign(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder1.build(change_address=sender_address)
+    tx_body = tx_builder1.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     tx_builder2 = TransactionBuilder(
         chain_context, [RandomImproveMultiAsset([0, 0, 0, 0, 0])]
@@ -827,7 +827,7 @@ def test_build_and_sign(chain_context):
     tx_builder2.add_input_address(sender).add_output(
         TransactionOutput.from_primitive([sender, 500000])
     )
-    tx = tx_builder2.build_and_sign([SK], change_address=sender_address)
+    tx = tx_builder2.build_and_sign([SK], change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     assert tx.transaction_witness_set.vkey_witnesses == [
         VerificationKeyWitness(SK.to_verification_key(), SK.sign(tx_body.hash()))
@@ -883,7 +883,7 @@ def test_tx_builder_exact_fee_no_change(chain_context):
 
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 5000000]))
 
-    tx_body = tx_builder.build()
+    tx_body = tx_builder.build(auto_validity=False, auto_required_signers=False)
 
     tx_builder = TransactionBuilder(chain_context)
 
@@ -897,7 +897,7 @@ def test_tx_builder_exact_fee_no_change(chain_context):
         TransactionOutput.from_primitive([sender, input_amount - tx_body.fee])
     )
 
-    tx = tx_builder.build_and_sign([SK])
+    tx = tx_builder.build_and_sign([SK], auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -933,7 +933,7 @@ def test_tx_builder_certificates(chain_context):
 
     tx_builder.certificates = [stake_registration, stake_delegation]
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -970,7 +970,7 @@ def test_tx_builder_withdrawal(chain_context):
     withdrawals = Withdrawals({bytes(stake_address): 10000})
     tx_builder.withdrawals = withdrawals
 
-    tx_body = tx_builder.build(change_address=sender_address)
+    tx_body = tx_builder.build(change_address=sender_address, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -1002,7 +1002,7 @@ def test_tx_builder_no_output(chain_context):
 
     tx_builder.add_input(utxo1)
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True)
+    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1029,7 +1029,7 @@ def test_tx_builder_merge_change_to_output(chain_context):
     tx_builder.add_input(utxo1)
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 10000]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True)
+    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1060,7 +1060,7 @@ def test_tx_builder_merge_change_to_output_2(chain_context):
     tx_builder.add_output(TransactionOutput.from_primitive([receiver, 10000]))
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 0]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True)
+    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1089,7 +1089,7 @@ def test_tx_builder_merge_change_to_zero_amount_output(chain_context):
     tx_builder.add_input(utxo1)
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 0]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True)
+    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -1116,7 +1116,7 @@ def test_tx_builder_merge_change_smaller_than_min_utxo(chain_context):
     tx_builder.add_input(utxo1)
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 9800000]))
 
-    tx_body = tx_builder.build(change_address=sender_address, merge_change=True)
+    tx_body = tx_builder.build(change_address=sender_address, merge_change=True, auto_validity=False, auto_required_signers=False)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -330,16 +330,16 @@ def test_tx_builder_mint_multi_asset(chain_context):
             [
                 sender_address.to_primitive(),
                 [
-                    5809683,
+                    5811003,
                     {b"1111111111111111111111111111": {b"Token1": 1, b"Token2": 2}},
                 ],
             ],
         ],
-        2: 190317,
+        2: 188997,
         3: 123456789,
         8: 1000,
         9: mint,
-        14: [sender_address.payment_part.to_primitive()],
+        14: [],
     }
 
     assert expected == tx_body.to_primitive()

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -59,9 +59,7 @@ def test_tx_builder(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -102,9 +100,7 @@ def test_tx_builder_with_certain_input(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [[b"22222222222222222222222222222222", 1]],
@@ -140,9 +136,7 @@ def test_tx_builder_multi_asset(chain_context):
         )
     )
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [
@@ -186,8 +180,6 @@ def test_tx_builder_raises_utxo_selection(chain_context):
     with pytest.raises(UTxOSelectionException) as e:
         tx_body = tx_builder.build(
             change_address=sender_address,
-            auto_validity=False,
-            auto_required_signers=False,
         )
 
     # The unfulfilled amount includes requested (991000000) and estimated fees (161277)
@@ -224,9 +216,7 @@ def test_tx_small_utxo_precise_fee(chain_context):
 
     # This will not fail as we replace max fee constraint with more precise fee calculation
     # And remainder is greater than minimum ada required for change
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expect = {
         0: [
@@ -278,9 +268,7 @@ def test_tx_small_utxo_balance_pass(chain_context):
 
     # Balance is smaller than minimum ada required in change
     # Additional UTxOs are selected from the input address
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [
@@ -315,7 +303,7 @@ def test_tx_builder_mint_multi_asset(chain_context):
 
     tx_builder = TransactionBuilder(chain_context)
     sender = "addr_test1vrm9x2zsux7va6w892g38tvchnzahvcd9tykqf3ygnmwtaqyfg52x"
-    sender_address = Address.from_primitive(sender)
+    sender_address: Address = Address.from_primitive(sender)
 
     # Add sender address as input
     mint = {policy_id.payload: {b"Token1": 1}}
@@ -326,9 +314,7 @@ def test_tx_builder_mint_multi_asset(chain_context):
     tx_builder.native_scripts = [script]
     tx_builder.ttl = 123456789
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [
@@ -344,14 +330,16 @@ def test_tx_builder_mint_multi_asset(chain_context):
             [
                 sender_address.to_primitive(),
                 [
-                    5811267,
+                    5809683,
                     {b"1111111111111111111111111111": {b"Token1": 1, b"Token2": 2}},
                 ],
             ],
         ],
-        2: 188733,
+        2: 190317,
         3: 123456789,
+        8: 1000,
         9: mint,
+        14: [sender_address.payment_part.to_primitive()],
     }
 
     assert expected == tx_body.to_primitive()
@@ -370,9 +358,7 @@ def test_tx_add_change_split_nfts(chain_context):
         TransactionOutput.from_primitive([sender, 7000000])
     )
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [
@@ -804,9 +790,7 @@ def test_excluded_input(chain_context):
 
     tx_builder.excluded_inputs.append(chain_context.utxos(sender)[0])
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [[b"22222222222222222222222222222222", 1]],
@@ -839,9 +823,7 @@ def test_build_and_sign(chain_context):
         TransactionOutput.from_primitive([sender, 500000])
     )
 
-    tx_body = tx_builder1.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder1.build(change_address=sender_address)
 
     tx_builder2 = TransactionBuilder(
         chain_context, [RandomImproveMultiAsset([0, 0, 0, 0, 0])]
@@ -852,8 +834,6 @@ def test_build_and_sign(chain_context):
     tx = tx_builder2.build_and_sign(
         [SK],
         change_address=sender_address,
-        auto_validity=False,
-        auto_required_signers=False,
     )
 
     assert tx.transaction_witness_set.vkey_witnesses == [
@@ -910,7 +890,7 @@ def test_tx_builder_exact_fee_no_change(chain_context):
 
     tx_builder.add_output(TransactionOutput.from_primitive([sender, 5000000]))
 
-    tx_body = tx_builder.build(auto_validity=False, auto_required_signers=False)
+    tx_body = tx_builder.build()
 
     tx_builder = TransactionBuilder(chain_context)
 
@@ -924,9 +904,7 @@ def test_tx_builder_exact_fee_no_change(chain_context):
         TransactionOutput.from_primitive([sender, input_amount - tx_body.fee])
     )
 
-    tx = tx_builder.build_and_sign(
-        [SK], auto_validity=False, auto_required_signers=False
-    )
+    tx = tx_builder.build_and_sign([SK])
 
     expected = {
         0: [[b"11111111111111111111111111111111", 3]],
@@ -962,9 +940,7 @@ def test_tx_builder_certificates(chain_context):
 
     tx_builder.certificates = [stake_registration, stake_delegation]
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -1001,9 +977,7 @@ def test_tx_builder_withdrawal(chain_context):
     withdrawals = Withdrawals({bytes(stake_address): 10000})
     tx_builder.withdrawals = withdrawals
 
-    tx_body = tx_builder.build(
-        change_address=sender_address, auto_validity=False, auto_required_signers=False
-    )
+    tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
         0: [[b"11111111111111111111111111111111", 0]],
@@ -1038,8 +1012,6 @@ def test_tx_builder_no_output(chain_context):
     tx_body = tx_builder.build(
         change_address=sender_address,
         merge_change=True,
-        auto_validity=False,
-        auto_required_signers=False,
     )
 
     expected = {
@@ -1070,8 +1042,6 @@ def test_tx_builder_merge_change_to_output(chain_context):
     tx_body = tx_builder.build(
         change_address=sender_address,
         merge_change=True,
-        auto_validity=False,
-        auto_required_signers=False,
     )
 
     expected = {
@@ -1106,8 +1076,6 @@ def test_tx_builder_merge_change_to_output_2(chain_context):
     tx_body = tx_builder.build(
         change_address=sender_address,
         merge_change=True,
-        auto_validity=False,
-        auto_required_signers=False,
     )
 
     expected = {
@@ -1140,8 +1108,6 @@ def test_tx_builder_merge_change_to_zero_amount_output(chain_context):
     tx_body = tx_builder.build(
         change_address=sender_address,
         merge_change=True,
-        auto_validity=False,
-        auto_required_signers=False,
     )
 
     expected = {
@@ -1172,8 +1138,6 @@ def test_tx_builder_merge_change_smaller_than_min_utxo(chain_context):
     tx_body = tx_builder.build(
         change_address=sender_address,
         merge_change=True,
-        auto_validity=False,
-        auto_required_signers=False,
     )
 
     expected = {

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -330,16 +330,16 @@ def test_tx_builder_mint_multi_asset(chain_context):
             [
                 sender_address.to_primitive(),
                 [
-                    5811003,
+                    5809683,
                     {b"1111111111111111111111111111": {b"Token1": 1, b"Token2": 2}},
                 ],
             ],
         ],
-        2: 188997,
+        2: 190317,
         3: 123456789,
         8: 1000,
         9: mint,
-        14: [],
+        14: [sender_address.payment_part.to_primitive()],
     }
 
     assert expected == tx_body.to_primitive()

--- a/test/pycardano/util.py
+++ b/test/pycardano/util.py
@@ -90,7 +90,7 @@ class FixedChainContext(ChainContext):
         return 300
 
     @property
-    def slot(self) -> int:
+    def last_block_slot(self) -> int:
         """Current slot number"""
         return 2000
 


### PR DESCRIPTION
Validity range and required signers are required by plutus scripts.
Users don't expect having to specify them if they add the utxos from specific addresses. Also validity range could be assumed to be somewhere around tx creation.

This PR adds the (default enabled) option to the transaction builder to automatically set the validity range and the required signers of the transaction to a reasonable value, which reduces friction for getting started with simple contracts.