### PR TITLE
Validate field type on serializing

### DIFF
--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -302,7 +302,7 @@ class CBORSerializable:
             if not _check_recursive(field_value, field_type):
                 raise TypeError(
                     f"Field '{field_name}' should be of type {field_type}, "
-                    f"got {type(field_value)} instead."
+                    f"got {repr(field_value)} instead."
                 )
 
     def to_validated_primitive(self) -> Primitive:

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -390,6 +390,7 @@ class TransactionOutput(CBORSerializable):
             self.amount = Value(self.amount)
 
     def validate(self):
+        super().validate()
         if isinstance(self.amount, int) and self.amount < 0:
             raise InvalidDataException(
                 f"Transaction output cannot have negative amount of ADA or "

--- a/test/pycardano/test_certificate.py
+++ b/test/pycardano/test_certificate.py
@@ -1,5 +1,6 @@
 from pycardano.address import Address
 from pycardano.certificate import (
+    PoolKeyHash,
     StakeCredential,
     StakeDelegation,
     StakeDeregistration,
@@ -43,7 +44,9 @@ def test_stake_deregistration():
 
 def test_stake_delegation():
     stake_credential = StakeCredential(TEST_ADDR.staking_part)
-    stake_delegation = StakeDelegation(stake_credential, b"1" * POOL_KEY_HASH_SIZE)
+    stake_delegation = StakeDelegation(
+        stake_credential, PoolKeyHash(b"1" * POOL_KEY_HASH_SIZE)
+    )
 
     assert (
         stake_delegation.to_cbor()


### PR DESCRIPTION
Validate each field in CBORSerializable during serialization. This will avoid bugs caused by incorrect type of field. For instance, when a field should be Address type, but being a string type instead, it would've been serialized successfully but failed to be deserialized.

This validation also helped discovering two minor type mismatch in unit tests. 🥳