### PR TITLE
Make use of spent_at and unspent flag

### DIFF
--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -258,7 +258,7 @@ class OgmiosChainContext(ChainContext):
                 "kupo_url object attribute has not been assigned properly."
             )
 
-        kupo_utxo_url = self._kupo_url + "/matches/" + address
+        kupo_utxo_url = self._kupo_url + "/matches/" + address + "?unspent"
         results = requests.get(kupo_utxo_url).json()
 
         utxos = []
@@ -267,11 +267,7 @@ class OgmiosChainContext(ChainContext):
             tx_id = result["transaction_id"]
             index = result["output_index"]
 
-            # Right now, all UTxOs of the address will be returned with Kupo, which requires Ogmios to
-            # validate if the UTxOs are spent with output reference. This feature is being considered to
-            # be added to Kupo to avoid extra API calls.
-            # See discussion here: https://github.com/CardanoSolutions/kupo/discussions/19.
-            if self._check_utxo_unspent(tx_id, index):
+            if result["spent_at"] is not None:
                 tx_in = TransactionInput.from_primitive([tx_id, index])
 
                 lovelace_amount = result["value"]["coins"]

--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -267,7 +267,7 @@ class OgmiosChainContext(ChainContext):
             tx_id = result["transaction_id"]
             index = result["output_index"]
 
-            if result["spent_at"] is not None:
+            if result["spent_at"] is None:
                 tx_in = TransactionInput.from_primitive([tx_id, index])
 
                 lovelace_amount = result["value"]["coins"]


### PR DESCRIPTION
This feature was released in v2.0.0 of kupo, which is several months old and can be expected (cf the release notes https://github.com/CardanoSolutions/kupo/releases/tag/v2.0.0-beta)

It will drastically reduce the time it takes to fetch utxos, as it does not start an ogmios lookup for every single utxo anymore!