### PR TITLE
Per default refetch the chain tip at most every 20 seconds

### DIFF
--- a/pycardano/backend/base.py
+++ b/pycardano/backend/base.py
@@ -8,7 +8,7 @@ from typeguard import typechecked
 from pycardano.address import Address
 from pycardano.network import Network
 from pycardano.plutus import ExecutionUnits
-from pycardano.transaction import UTxO, Transaction
+from pycardano.transaction import Transaction, UTxO
 
 __all__ = [
     "GenesisParameters",

--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -56,17 +56,19 @@ class OgmiosChainContext(ChainContext):
         network: Network,
         compact_result=True,
         kupo_url=None,
-        refetch_chain_tip_interval=20,
+        refetch_chain_tip_interval: Optional[int]=None,
     ):
         self._ws_url = ws_url
         self._network = network
         self._service_name = "ogmios.v1:compact" if compact_result else "ogmios"
         self._kupo_url = kupo_url
         self._last_known_block_slot = 0
-        self._refetch_chain_tip_interval = refetch_chain_tip_interval
+        self._refetch_chain_tip_interval = refetch_chain_tip_interval if refetch_chain_tip_interval is not None else 1000
         self._last_chain_tip_fetch = 0
         self._genesis_param = None
         self._protocol_param = None
+        if refetch_chain_tip_interval is None:
+            self._refetch_chain_tip_interval = self.genesis_param.slot_length / self.genesis_param.active_slots_coefficient
 
     def _request(self, method: OgmiosQueryType, args: JsonDict) -> Any:
         ws = websocket.WebSocket()

--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -56,19 +56,26 @@ class OgmiosChainContext(ChainContext):
         network: Network,
         compact_result=True,
         kupo_url=None,
-        refetch_chain_tip_interval: Optional[int]=None,
+        refetch_chain_tip_interval: Optional[float] = None,
     ):
         self._ws_url = ws_url
         self._network = network
         self._service_name = "ogmios.v1:compact" if compact_result else "ogmios"
         self._kupo_url = kupo_url
         self._last_known_block_slot = 0
-        self._refetch_chain_tip_interval = refetch_chain_tip_interval if refetch_chain_tip_interval is not None else 1000
+        self._refetch_chain_tip_interval = (
+            refetch_chain_tip_interval
+            if refetch_chain_tip_interval is not None
+            else 1000
+        )
         self._last_chain_tip_fetch = 0
         self._genesis_param = None
         self._protocol_param = None
         if refetch_chain_tip_interval is None:
-            self._refetch_chain_tip_interval = self.genesis_param.slot_length / self.genesis_param.active_slots_coefficient
+            self._refetch_chain_tip_interval = (
+                self.genesis_param.slot_length
+                / self.genesis_param.active_slots_coefficient
+            )
 
     def _request(self, method: OgmiosQueryType, args: JsonDict) -> Any:
         ws = websocket.WebSocket()

--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -1,8 +1,8 @@
 import json
+import time
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
-import time
 
 import cbor2
 import requests


### PR DESCRIPTION
At the current state, every access to protocol params causes at least one chain tip fetch. Due to the potential delay of this request, often another protocol params fetch is triggered as well.

This significantly (and mostly unnecessarily) slows down transaction building. This fix caches the chain tip for a default of 20 seconds (the average slot time), making sure that subsequent calls to _is_chain_tip_updated return without any delay, drastically speeding up tx building.