### PR TITLE
Fix/parse raw plutus data

### DIFF
--- a/pycardano/plutus.py
+++ b/pycardano/plutus.py
@@ -693,7 +693,7 @@ class RawPlutusData(CBORSerializable):
         return cls(value)
 
 
-Datum = Union[PlutusData, dict, IndefiniteList, int, bytes, RawCBOR, RawPlutusData]
+Datum = Union[PlutusData, dict, int, bytes, IndefiniteList, RawCBOR, RawPlutusData]
 """Plutus Datum type. A Union type that contains all valid datum types."""
 
 

--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -496,7 +496,10 @@ def _restore_typed_primitive(
             raise DeserializeException(f"Expected type list but got {type(v)}")
         return IndefiniteList([_restore_typed_primitive(t, w) for w in v])
     elif isclass(t) and issubclass(t, IndefiniteList):
-        return IndefiniteList(v)
+        try:
+            return IndefiniteList(v)
+        except TypeError:
+            raise DeserializeException(f"Can not initialize IndefiniteList from {v}")
     elif hasattr(t, "__origin__") and (t.__origin__ is dict):
         t_args = t.__args__
         if len(t_args) != 2:

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1,6 +1,7 @@
+import cbor2
 from dataclasses import dataclass, field
 
-from pycardano import Datum
+from pycardano import Datum, RawPlutusData
 from test.pycardano.util import check_two_way_cbor
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -181,7 +182,13 @@ def test_datum_type():
     class Test1(MapCBORSerializable):
         b: Datum
 
-    t = Test1(b=1)
+    # make sure that no "not iterable" error is thrown
+    t = Test1(b=RawPlutusData(cbor2.CBORTag(125, [])))
+
+    check_two_way_cbor(t)
+
+    # Make sure that iterable objects are not deserialized to the wrong object
+    t = Test1(b=b"hello!")
 
     check_two_way_cbor(t)
 

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass, field
+
+from pycardano import Datum
 from test.pycardano.util import check_two_way_cbor
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -170,6 +172,16 @@ def test_any_type():
         b: Any = ""
 
     t = Test1(a="a", b=1)
+
+    check_two_way_cbor(t)
+
+
+def test_datum_type():
+    @dataclass
+    class Test1(MapCBORSerializable):
+        b: Datum
+
+    t = Test1(b=1)
 
     check_two_way_cbor(t)
 


### PR DESCRIPTION
When annotating serializable classes with Datum, the deserialization would fail when trying to initialize an IndefiniteList from the given object. This fixes the issue (the result will be RawPlutusData)