### PR TITLE
Support potential inputs in txbuilder

### DIFF
--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -122,6 +122,39 @@ def test_tx_builder_with_certain_input(chain_context):
     assert expected == tx_body.to_primitive()
 
 
+def test_tx_builder_with_potential_inputs(chain_context):
+    tx_builder = TransactionBuilder(chain_context, [RandomImproveMultiAsset([0, 0])])
+    sender = "addr_test1vrm9x2zsux7va6w892g38tvchnzahvcd9tykqf3ygnmwtaqyfg52x"
+    sender_address = Address.from_primitive(sender)
+
+    utxos = chain_context.utxos(sender)
+
+    tx_builder.potential_inputs.append(utxos[1])
+
+    tx_builder.add_output(TransactionOutput.from_primitive([sender, 500000]))
+
+    tx_body = tx_builder.build(change_address=sender_address)
+
+    expected = {
+        0: [[b"22222222222222222222222222222222", 1]],
+        1: [
+            # First output
+            [sender_address.to_primitive(), 500000],
+            # Second output as change
+            [
+                sender_address.to_primitive(),
+                [
+                    5332431,
+                    {b"1111111111111111111111111111": {b"Token1": 1, b"Token2": 2}},
+                ],
+            ],
+        ],
+        2: 167569,
+    }
+
+    assert expected == tx_body.to_primitive()
+
+
 def test_tx_builder_multi_asset(chain_context):
     tx_builder = TransactionBuilder(chain_context)
     sender = "addr_test1vrm9x2zsux7va6w892g38tvchnzahvcd9tykqf3ygnmwtaqyfg52x"


### PR DESCRIPTION
This feature will allow users to define a list of potential utxo, which could be returned by a wallet, for UTxO selector to select inputs from.
Addresses https://github.com/Python-Cardano/pycardano/issues/204