### PR TITLE
Fix reference scripts fetched from ogmios

### DIFF
--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -466,9 +466,9 @@ class OgmiosChainContext(ChainContext):
         script = output.get("script", None)
         if script:
             if "plutus:v2" in script:
-                script = PlutusV2Script(cbor2.loads(bytes.fromhex(script["plutus:v2"])))
+                script = PlutusV2Script(bytes.fromhex(script["plutus:v2"]))
             elif "plutus:v1" in script:
-                script = PlutusV1Script(cbor2.loads(bytes.fromhex(script["plutus:v1"])))
+                script = PlutusV1Script(bytes.fromhex(script["plutus:v1"]))
             else:
                 raise ValueError("Unknown plutus script type")
         datum_hash = (

--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import cbor2
 import requests
 import websocket
 from cachetools import Cache, LRUCache, TTLCache, func


### PR DESCRIPTION
Same fix as for kupo (#253) for #252 

@ktorz maybe you can chime in on what exactly the format of scripts in utxos is in kupo/ogmios? Its mentioned to be[ "raw script"](https://cardanosolutions.github.io/kupo/#tag/Scripts/paths/~1scripts~1{script-hash}/get) from which I would actually understand 0 cbor wrapping but it appears to be exactly once?