### PR TITLE
Add add_native_script method to TransactionBuilder

### DIFF
--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -291,6 +291,21 @@ class TransactionBuilder:
             self._minting_script_to_redeemers.append((script, redeemer))
         return self
 
+    def add_native_script(self, script: NativeScript) -> TransactionBuilder:
+        """Add a native script to this transaction
+
+        Args:
+            script (NativeScript): Script to be added.
+
+        Returns:
+            TransactionBuilder: The current transaction builder.
+        """
+        if isinstance(self.native_scripts, list):
+            self.native_scripts.append(script)
+        else:
+            self.native_scripts = [script]
+        return self
+
     def add_input_address(self, address: Union[Address, str]) -> TransactionBuilder:
         """Add an address to transaction's input address.
         Unlike :meth:`add_input`, which deterministically adds a UTxO to the transaction's inputs, `add_input_address`


### PR DESCRIPTION
When creating a transaction spending funds from a script address, there is no obvious way of adding the script input to the transaction.

One way is to manually select the input UTxOs and then add them to the transaction using:
`builder.add_script_input(utxo, native_script)`

But if you want to let PyCardano select tin input UTxOs from the script address:
`builder.add_input_address(script_address)`
then you must manually add the native script like this:
`builder.native_scripts = [native_script]`
but you need to check if `builder.native_scripts` is not already containing native scripts.

With this new method, it would me more straightforward:
`builder.add_native_script(native_script)`
