### PR TITLE
Fix: negative minted amount is also requested

### DIFF
--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -934,7 +934,13 @@ class TransactionBuilder:
             selected_amount += i.output.amount
 
         if self.mint:
-            selected_amount.multi_asset += self.mint
+            # Add positive minted amounts to the selected amount (=source)
+            for pid, m in self.mint.items():
+                for tkn, am in m.items():
+                    if am < 0:
+                        selected_amount += Value(
+                            multi_asset=MultiAsset({pid: Asset({tkn: am})})
+                        )
 
         if self.withdrawals:
             for v in self.withdrawals.values():
@@ -954,6 +960,7 @@ class TransactionBuilder:
             requested_amount += o.amount
 
         if self.mint:
+            # Add negative minted amounts to the requested amount (=sink)
             for pid, m in self.mint.items():
                 for tkn, am in m.items():
                     if am < 0:

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -952,11 +952,13 @@ class TransactionBuilder:
         requested_amount = Value()
         for o in self.outputs:
             requested_amount += o.amount
-        
+
         for pid, m in self.mint.items():
             for tkn, am in m.items():
                 if am < 0:
-                    requested_amount += Value(multi_asset=MultiAsset({pid: Asset({tkn: -am})}))
+                    requested_amount += Value(
+                        multi_asset=MultiAsset({pid: Asset({tkn: -am})})
+                    )
 
         # Include min fees associated as part of requested amount
         requested_amount += self._estimate_fee()

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -953,12 +953,13 @@ class TransactionBuilder:
         for o in self.outputs:
             requested_amount += o.amount
 
-        for pid, m in self.mint.items():
-            for tkn, am in m.items():
-                if am < 0:
-                    requested_amount += Value(
-                        multi_asset=MultiAsset({pid: Asset({tkn: -am})})
-                    )
+        if self.mint:
+            for pid, m in self.mint.items():
+                for tkn, am in m.items():
+                    if am < 0:
+                        requested_amount += Value(
+                            multi_asset=MultiAsset({pid: Asset({tkn: -am})})
+                        )
 
         # Include min fees associated as part of requested amount
         requested_amount += self._estimate_fee()

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -937,7 +937,7 @@ class TransactionBuilder:
             # Add positive minted amounts to the selected amount (=source)
             for pid, m in self.mint.items():
                 for tkn, am in m.items():
-                    if am < 0:
+                    if am > 0:
                         selected_amount += Value(
                             multi_asset=MultiAsset({pid: Asset({tkn: am})})
                         )

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -952,6 +952,11 @@ class TransactionBuilder:
         requested_amount = Value()
         for o in self.outputs:
             requested_amount += o.amount
+        
+        for pid, m in self.mint.items():
+            for tkn, am in m.items():
+                if am < 0:
+                    requested_amount += Value(multi_asset=MultiAsset({pid: Asset({tkn: -am})}))
 
         # Include min fees associated as part of requested amount
         requested_amount += self._estimate_fee()


### PR DESCRIPTION
For transactions that only specified a token to be burned it could currently happen that the token was not selected by the input selector - because negative minting amounts were not counted as requested by the tx builder. This is a bugfix.

- [x] Add a unit test