### PR TITLE
Use potential inputs to satisfy collateral amount

### DIFF
--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -1135,6 +1135,13 @@ class TransactionBuilder:
 
             if tmp_val.coin < collateral_amount:
                 sorted_inputs = sorted(
+                    self.potential_inputs,
+                    key=lambda i: (len(i.output.to_cbor_hex()), -i.output.amount.coin),
+                )
+                _add_collateral_input(tmp_val, sorted_inputs)
+
+            if tmp_val.coin < collateral_amount:
+                sorted_inputs = sorted(
                     self.context.utxos(collateral_return_address),
                     key=lambda i: (len(i.output.to_cbor_hex()), -i.output.amount.coin),
                 )


### PR DESCRIPTION
This fixes an issue where the inputs given as potential inputs may be enough to satisfy the minimum collateral, but are not used. This would then result in an issue later, that the total sum of coins in the collaterals is not enough to satisfy minimum collateral return.