### PR TITLE
Add function to convert a PlutusData object into a Plutus Blueprint Schema

### DIFF
--- a/pycardano/plutus.py
+++ b/pycardano/plutus.py
@@ -916,14 +916,7 @@ def to_plutus_schema(cls: Type[Datum]) -> dict:
     Returns:
         dict: a dict representing the schema of this class.
     """
-
-    if issubclass(cls, bytes) or issubclass(cls, ByteString):
-        return {"dataType": "bytes"}
-    elif issubclass(cls, int):
-        return {"dataType": "integer"}
-    elif issubclass(cls, IndefiniteList) or issubclass(cls, list):
-        return {"dataType": "list"}
-    elif hasattr(cls, "__origin__") and cls.__origin__ is list:
+    if hasattr(cls, "__origin__") and cls.__origin__ is list:
         return {
             "dataType": "list",
             **(
@@ -953,6 +946,8 @@ def to_plutus_schema(cls: Type[Datum]) -> dict:
     elif issubclass(cls, PlutusData):
         fields = []
         for field_value in cls.__dataclass_fields__.values():
+            if field_value.name == "CONSTR_ID":
+                continue
             field_schema = to_plutus_schema(field_value.type)
             field_schema["title"] = field_value.name
             fields.append(field_schema)
@@ -961,5 +956,11 @@ def to_plutus_schema(cls: Type[Datum]) -> dict:
             "index": cls.CONSTR_ID,
             "fields": fields,
         }
+    elif issubclass(cls, bytes) or issubclass(cls, ByteString):
+        return {"dataType": "bytes"}
+    elif issubclass(cls, int):
+        return {"dataType": "integer"}
+    elif issubclass(cls, IndefiniteList) or issubclass(cls, list):
+        return {"dataType": "list"}
     else:
         return {}

--- a/pycardano/plutus.py
+++ b/pycardano/plutus.py
@@ -952,6 +952,14 @@ def to_plutus_schema(cls: Type[Datum]) -> dict:
         }
     elif issubclass(cls, PlutusData):
         fields = []
-        pass
+        for field_value in cls.__dataclass_fields__.values():
+            field_schema = to_plutus_schema(field_value.type)
+            field_schema["title"] = field_value.name
+            fields.append(field_schema)
+        return {
+            "dataType": "constructor",
+            "index": cls.CONSTR_ID,
+            "fields": fields,
+        }
     else:
         return {}


### PR DESCRIPTION
As part of https://github.com/OpShin/opshin/issues/57, OpShin will have to convert PlutusData-ish arguments to smart contracts into the Plutus Blueprint Schema ([CIP 57](https://cips.cardano.org/cips/cip57/#corevocabulary)). Since this utility seems useful outside of OpShin, I propose to add the function here.