### PR TITLE
Fix transaction submission example

### DIFF
--- a/docs/source/guides/transaction.rst
+++ b/docs/source/guides/transaction.rst
@@ -178,5 +178,5 @@ Transaction submission
 Once we have a signed transaction, it could be submitted to the network. The easiest way to do so is through a chain
 context::
 
-    >>> context.submit_tx(signed_tx.to_cbor_hex())
+    >>> context.submit_tx(signed_tx)
 


### PR DESCRIPTION
The API seems to expect the whole transaction object, not just CBOR bytes

This is a reopen of https://github.com/cffls/pycardano/pull/1