### PR TITLE
Fix the printing of RawPlutusData

### DIFF
--- a/pycardano/plutus.py
+++ b/pycardano/plutus.py
@@ -773,6 +773,9 @@ class RawPlutusData(CBORSerializable):
     def __deepcopy__(self, memo):
         return self.__class__.from_cbor(self.to_cbor_hex())
 
+    def __repr__(self):
+        return f"RawPlutusData(data={repr(self.data)})"
+
 
 Datum = Union[PlutusData, dict, int, bytes, IndefiniteList, RawCBOR, RawPlutusData]
 """Plutus Datum type. A Union type that contains all valid datum types."""

--- a/pycardano/plutus.py
+++ b/pycardano/plutus.py
@@ -745,7 +745,7 @@ class PlutusData(ArrayCBORSerializable):
         return self.__class__.from_cbor(self.to_cbor_hex())
 
 
-@dataclass(repr=False)
+@dataclass(repr=True)
 class RawPlutusData(CBORSerializable):
     data: CBORTag
 
@@ -772,9 +772,6 @@ class RawPlutusData(CBORSerializable):
 
     def __deepcopy__(self, memo):
         return self.__class__.from_cbor(self.to_cbor_hex())
-
-    def __repr__(self):
-        return f"RawPlutusData(data={repr(self.data)})"
 
 
 Datum = Union[PlutusData, dict, int, bytes, IndefiniteList, RawCBOR, RawPlutusData]


### PR DESCRIPTION
Some recent change in the codebase led to pretty printing of Raw Plutus Data to invoke a pretty printer. This is problematic for two reasons:

- OpShin mimiced the behaviour of PyCardano to print RawPlutusData in the most precise way possible
- The pretty printer re-orders dictionaries (i.e. sorts them). This may lead to the representation of the dictionary not being faithful to the original representation anymore (specifically, could lead to a different CBOR hex)

Another way to tackle this might be to change the behaviour of the pretty printer (inherited from CBORSerializable) to not sort entries in dictionaries anymore (as this could also break CBOR matching)