### PR TITLE
Use Fraction for protocol parameters

### DIFF
--- a/pycardano/backend/base.py
+++ b/pycardano/backend/base.py
@@ -1,6 +1,7 @@
 """Defines interfaces for client codes to interact (read/write) with the blockchain."""
 
 from dataclasses import dataclass
+from fractions import Fraction
 from typing import Dict, List, Union
 
 from pycardano.address import Address
@@ -24,7 +25,7 @@ ALONZO_COINS_PER_UTXO_WORD = 34482
 class GenesisParameters:
     """Cardano genesis parameters"""
 
-    active_slots_coefficient: float
+    active_slots_coefficient: Fraction
 
     update_quorum: int
 
@@ -63,13 +64,13 @@ class ProtocolParameters:
 
     pool_deposit: int
 
-    pool_influence: float
+    pool_influence: Fraction
 
-    monetary_expansion: float
+    monetary_expansion: Fraction
 
-    treasury_expansion: float
+    treasury_expansion: Fraction
 
-    decentralization_param: float
+    decentralization_param: Fraction
 
     extra_entropy: str
 
@@ -81,9 +82,9 @@ class ProtocolParameters:
 
     min_pool_cost: int
 
-    price_mem: float
+    price_mem: Fraction
 
-    price_step: float
+    price_step: Fraction
 
     max_tx_ex_mem: int
 

--- a/pycardano/backend/blockfrost.py
+++ b/pycardano/backend/blockfrost.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import time
 import warnings
+from fractions import Fraction
 from typing import Dict, List, Optional, Union
 
 import cbor2
@@ -133,17 +134,17 @@ class BlockFrostChainContext(ChainContext):
                 max_block_header_size=int(params.max_block_header_size),
                 key_deposit=int(params.key_deposit),
                 pool_deposit=int(params.pool_deposit),
-                pool_influence=float(params.a0),
-                monetary_expansion=float(params.rho),
-                treasury_expansion=float(params.tau),
-                decentralization_param=float(params.decentralisation_param),
+                pool_influence=Fraction(params.a0),
+                monetary_expansion=Fraction(params.rho),
+                treasury_expansion=Fraction(params.tau),
+                decentralization_param=Fraction(params.decentralisation_param),
                 extra_entropy=params.extra_entropy,
                 protocol_major_version=int(params.protocol_major_ver),
                 protocol_minor_version=int(params.protocol_minor_ver),
                 min_utxo=int(params.min_utxo),
                 min_pool_cost=int(params.min_pool_cost),
-                price_mem=float(params.price_mem),
-                price_step=float(params.price_step),
+                price_mem=Fraction(params.price_mem),
+                price_step=Fraction(params.price_step),
                 max_tx_ex_mem=int(params.max_tx_ex_mem),
                 max_tx_ex_steps=int(params.max_tx_ex_steps),
                 max_block_ex_mem=int(params.max_block_ex_mem),

--- a/pycardano/backend/cardano_cli.py
+++ b/pycardano/backend/cardano_cli.py
@@ -143,7 +143,7 @@ class CardanoCliChainContext(ChainContext):
         self._genesis_param = None
         self._protocol_param = None
         if refetch_chain_tip_interval is None:
-            self._refetch_chain_tip_interval = (
+            self._refetch_chain_tip_interval = float(
                 self.genesis_param.slot_length
                 / self.genesis_param.active_slots_coefficient
             )

--- a/pycardano/backend/ogmios.py
+++ b/pycardano/backend/ogmios.py
@@ -2,6 +2,7 @@ import json
 import time
 from datetime import datetime, timezone
 from enum import Enum
+from fractions import Fraction
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
@@ -77,7 +78,7 @@ class OgmiosChainContext(ChainContext):
         self._genesis_param = None
         self._protocol_param = None
         if refetch_chain_tip_interval is None:
-            self._refetch_chain_tip_interval = (
+            self._refetch_chain_tip_interval = float(
                 self.genesis_param.slot_length
                 / self.genesis_param.active_slots_coefficient
             )
@@ -146,9 +147,8 @@ class OgmiosChainContext(ChainContext):
             return False
 
     @staticmethod
-    def _fraction_parser(fraction: str) -> float:
-        x, y = fraction.split("/")
-        return int(x) / int(y)
+    def _fraction_parser(fraction: str) -> Fraction:
+        return Fraction(fraction)
 
     @property
     def protocol_param(self) -> ProtocolParameters:

--- a/test/pycardano/backend/test_ogmios.py
+++ b/test/pycardano/backend/test_ogmios.py
@@ -1,3 +1,4 @@
+from fractions import Fraction
 from unittest.mock import patch
 
 import pytest
@@ -130,17 +131,17 @@ class TestOgmiosChainContext:
                 max_block_header_size=1100,
                 key_deposit=0,
                 pool_deposit=0,
-                pool_influence=0.0,
-                monetary_expansion=0.1,
-                treasury_expansion=0.1,
-                decentralization_param=1.0,
+                pool_influence=Fraction("0"),
+                monetary_expansion=Fraction("1/10"),
+                treasury_expansion=Fraction("1/10"),
+                decentralization_param=Fraction("1"),
                 extra_entropy="neutral",
                 protocol_major_version=5,
                 protocol_minor_version=0,
                 min_utxo=1000000,
                 min_pool_cost=0,
-                price_mem=0.1,
-                price_step=0.1,
+                price_mem=Fraction("1/10"),
+                price_step=Fraction("1/10"),
                 max_tx_ex_mem=500000000000,
                 max_tx_ex_steps=500000000000,
                 max_block_ex_mem=500000000000,
@@ -158,7 +159,7 @@ class TestOgmiosChainContext:
     def test_genesis(self, chain_context):
         assert (
             GenesisParameters(
-                active_slots_coefficient=0.1,
+                active_slots_coefficient=Fraction("1/10"),
                 update_quorum=2,
                 max_lovelace_supply=1000000000000,
                 network_magic=42,


### PR DESCRIPTION
In the spirit of #292 and #299 there might be a need to make the fee computation more precise. At the size of execution units and step sizes (order of magnitude 10M - 1B) the imprecisions of float could also be an issue. Ogmios conveniently provides parameters already in Fraction format, parseable by the python native fractions library.