### PR TITLE
Allow subtracting assets if not existing before 

### DIFF
--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -14,7 +14,7 @@ from nacl.hash import blake2b
 
 from pycardano.address import Address
 from pycardano.certificate import Certificate
-from pycardano.exception import InvalidDataException, InvalidOperationException
+from pycardano.exception import InvalidDataException
 from pycardano.hash import (
     TRANSACTION_HASH_SIZE,
     AuxiliaryDataHash,
@@ -95,14 +95,7 @@ class Asset(DictCBORSerializable):
     def __sub__(self, other: Asset) -> Asset:
         new_asset = deepcopy(self)
         for n in other:
-            if n not in new_asset:
-                raise InvalidOperationException(
-                    f"Asset: {new_asset} does not have asset with name: {n}"
-                )
-            # According to ledger rule, the value of an asset could be negative, so we don't check the value here and
-            # will leave the check to users when necessary.
-            # https://github.com/input-output-hk/cardano-ledger/blob/master/eras/alonzo/test-suite/cddl-files/alonzo.cddl#L378
-            new_asset[n] -= other[n]
+            new_asset[n] = new_asset.get(n, 0) - other[n]
         return new_asset
 
     def __eq__(self, other):
@@ -135,9 +128,7 @@ class MultiAsset(DictCBORSerializable):
     def __add__(self, other):
         new_multi_asset = deepcopy(self)
         for p in other:
-            if p not in new_multi_asset:
-                new_multi_asset[p] = Asset()
-            new_multi_asset[p] += other[p]
+            new_multi_asset[p] = new_multi_asset.get(p, Asset()) + other[p]
         return new_multi_asset
 
     def __iadd__(self, other):
@@ -148,11 +139,7 @@ class MultiAsset(DictCBORSerializable):
     def __sub__(self, other: MultiAsset) -> MultiAsset:
         new_multi_asset = deepcopy(self)
         for p in other:
-            if p not in new_multi_asset:
-                raise InvalidOperationException(
-                    f"MultiAsset: {new_multi_asset} doesn't have policy: {p}"
-                )
-            new_multi_asset[p] -= other[p]
+            new_multi_asset[p] = new_multi_asset.get(p, Asset()) - other[p]
         return new_multi_asset
 
     def __eq__(self, other):

--- a/test/pycardano/test_transaction.py
+++ b/test/pycardano/test_transaction.py
@@ -311,8 +311,12 @@ def test_multi_asset_subtraction():
         }
     )
 
-    with pytest.raises(InvalidOperationException):
-        a - b
+    assert a - b == MultiAsset.from_primitive(
+        {
+            b"1" * SCRIPT_HASH_SIZE: {b"Token1": -9, b"Token2": -18},
+            b"2" * SCRIPT_HASH_SIZE: {b"Token1": -1, b"Token2": -2},
+        }
+    )
 
 
 def test_asset_comparison():
@@ -427,11 +431,25 @@ def test_values():
         [101, {b"1" * SCRIPT_HASH_SIZE: {b"Token1": 1, b"Token2": 2}}]
     )
 
-    with pytest.raises(InvalidOperationException):
-        a - c
+    assert a - c == Value.from_primitive(
+        [
+            -10,
+            {
+                b"1" * SCRIPT_HASH_SIZE: {b"Token1": -10, b"Token2": -20},
+                b"2" * SCRIPT_HASH_SIZE: {b"Token1": -11, b"Token2": -22},
+            },
+        ]
+    )
 
-    with pytest.raises(InvalidOperationException):
-        b - c
+    assert b - c == Value.from_primitive(
+        [
+            0,
+            {
+                b"1" * SCRIPT_HASH_SIZE: {b"Token1": 0, b"Token2": 0},
+                b"2" * SCRIPT_HASH_SIZE: {b"Token1": -11, b"Token2": -22},
+            },
+        ]
+    )
 
 
 def test_inline_datum_serdes():


### PR DESCRIPTION
Negative values were allowed before as well so it is only consequential to allow subtracting from 0. This simplifies edge case handling for tools that simply want to operate on Values. Is there any inherent rule/implementation in the ledger that lead to the previous error situation?