### PR TITLE
Correct variable name and Address input in docs example

### DIFF
--- a/docs/source/guides/transaction.rst
+++ b/docs/source/guides/transaction.rst
@@ -119,7 +119,7 @@ Read signing key into the program and generate its corresponding verification ke
     >>> network = Network.TESTNET
     >>> sk = PaymentSigningKey.load("path/to/payment.skey")
     >>> vk = PaymentVerificationKey.from_signing_key(sk)
-    >>> address = Address(pvk.hash(), svk.hash(), network)
+    >>> address = Address(vk.hash(), network)
 
 
 Step 3


### PR DESCRIPTION
Hi all,

Just a small modification to the example that makes it runnable. Maybe Address() at one time required the hash() of both keys that doesn't seem to be the case anymore. Cheers!