### PR TITLE
Update node version for integration tests

### DIFF
--- a/integration-test/configs/local-alonzo/config.json
+++ b/integration-test/configs/local-alonzo/config.json
@@ -2,6 +2,7 @@
   "ByronGenesisFile": "byron-genesis.json",
   "ShelleyGenesisFile": "shelley-genesis.json",
   "AlonzoGenesisFile": "alonzo-genesis.json",
+  "ConwayGenesisFile": "conway-genesis.json",
   "SocketPath": "db/node.socket",
   "MaxConcurrencyBulkSync": 1,
   "MaxConcurrencyDeadline": 2,
@@ -99,6 +100,6 @@
   "TestAllegraHardForkAtEpoch": 0,
   "TestMaryHardForkAtEpoch": 0,
   "TestAlonzoHardForkAtEpoch": 0,
-  "TestEnableDevelopmentHardForkEras": true,
-  "TestEnableDevelopmentNetworkProtocols": true
+  "EnableDevelopmentHardForkEras": true,
+  "ExperimentalProtocolsEnabled": true
 }

--- a/integration-test/configs/local-alonzo/conway-genesis.json
+++ b/integration-test/configs/local-alonzo/conway-genesis.json
@@ -1,0 +1,39 @@
+{
+  "poolVotingThresholds": {
+    "committeeNormal": 0.51,
+    "committeeNoConfidence": 0.51,
+    "hardForkInitiation": 0.51,
+    "motionNoConfidence": 0.51,
+    "ppSecurityGroup": 0.51
+  },
+  "dRepVotingThresholds": {
+    "motionNoConfidence": 0.51,
+    "committeeNormal": 0.51,
+    "committeeNoConfidence": 0.51,
+    "updateToConstitution": 0.51,
+    "hardForkInitiation": 0.51,
+    "ppNetworkGroup": 0.51,
+    "ppEconomicGroup": 0.51,
+    "ppTechnicalGroup": 0.51,
+    "ppGovGroup": 0.51,
+    "treasuryWithdrawal": 0.51
+  },
+  "committeeMinSize": 0,
+  "committeeMaxTermLength": 200,
+  "govActionLifetime": 10,
+  "govActionDeposit": 1000000000,
+  "dRepDeposit": 2000000,
+  "dRepActivity": 20,
+  "constitution": {
+    "anchor": {
+      "url": "",
+      "dataHash": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  "committee": {
+    "members": {
+
+    },
+    "quorum": 0
+  }
+}

--- a/integration-test/configs/local-vasil/config.json
+++ b/integration-test/configs/local-vasil/config.json
@@ -2,6 +2,7 @@
   "ByronGenesisFile": "byron-genesis.json",
   "ShelleyGenesisFile": "shelley-genesis.json",
   "AlonzoGenesisFile": "alonzo-genesis.json",
+  "ConwayGenesisFile": "conway-genesis.json",
   "SocketPath": "db/node.socket",
   "MaxConcurrencyBulkSync": 1,
   "MaxConcurrencyDeadline": 2,
@@ -100,6 +101,6 @@
   "TestMaryHardForkAtEpoch": 0,
   "TestAlonzoHardForkAtEpoch": 0,
   "TestBabbageHardForkAtEpoch": 10,
-  "TestEnableDevelopmentHardForkEras": true,
-  "TestEnableDevelopmentNetworkProtocols": true
+  "EnableDevelopmentHardForkEras": true,
+  "ExperimentalProtocolsEnabled": true
 }

--- a/integration-test/configs/local-vasil/conway-genesis.json
+++ b/integration-test/configs/local-vasil/conway-genesis.json
@@ -1,0 +1,39 @@
+{
+  "poolVotingThresholds": {
+    "committeeNormal": 0.51,
+    "committeeNoConfidence": 0.51,
+    "hardForkInitiation": 0.51,
+    "motionNoConfidence": 0.51,
+    "ppSecurityGroup": 0.51
+  },
+  "dRepVotingThresholds": {
+    "motionNoConfidence": 0.51,
+    "committeeNormal": 0.51,
+    "committeeNoConfidence": 0.51,
+    "updateToConstitution": 0.51,
+    "hardForkInitiation": 0.51,
+    "ppNetworkGroup": 0.51,
+    "ppEconomicGroup": 0.51,
+    "ppTechnicalGroup": 0.51,
+    "ppGovGroup": 0.51,
+    "treasuryWithdrawal": 0.51
+  },
+  "committeeMinSize": 0,
+  "committeeMaxTermLength": 200,
+  "govActionLifetime": 10,
+  "govActionDeposit": 1000000000,
+  "dRepDeposit": 2000000,
+  "dRepActivity": 20,
+  "constitution": {
+    "anchor": {
+      "url": "",
+      "dataHash": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  "committee": {
+    "members": {
+
+    },
+    "quorum": 0
+  }
+}

--- a/integration-test/docker-compose.yml
+++ b/integration-test/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 services:
 
   cardano-node:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.7}
+    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-8.9.2}
     entrypoint: bash
     environment:
       NETWORK: "${NETWORK:-local-alonzo}"
@@ -34,7 +34,7 @@ services:
         max-file: "10"
 
   cardano-pool:
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.7}
+    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-8.9.2}
     entrypoint: bash
     environment:
       NETWORK: "${NETWORK:-local-alonzo}"
@@ -54,7 +54,7 @@ services:
         max-file: "10"
 
   ogmios:
-    image: cardanosolutions/ogmios:v5.6.0-mainnet
+    image: cardanosolutions/ogmios:v6.2.0
     environment:
       NETWORK: "${NETWORK:-local-alonzo}"
 

--- a/integration-test/run_tests.sh
+++ b/integration-test/run_tests.sh
@@ -6,6 +6,7 @@ set -o pipefail
 ROOT=$(pwd)
 
 poetry install
+poetry run pip install ogmios
 
 ##########
 # Alonzo #

--- a/integration-test/test/base.py
+++ b/integration-test/test/base.py
@@ -7,6 +7,8 @@ from retry import retry
 
 from pycardano import *
 
+from ogmios import OgmiosChainContext
+
 TEST_RETRIES = 6
 
 
@@ -19,11 +21,10 @@ class TestBase:
     # Define chain context
     NETWORK = Network.TESTNET
 
-    OGMIOS_WS = "ws://localhost:1337"
-
+    # TODO: Bring back kupo test
     KUPO_URL = "http://localhost:1442"
 
-    chain_context = OgmiosChainContext(OGMIOS_WS, Network.TESTNET, kupo_url=KUPO_URL)
+    chain_context = OgmiosChainContext(host="localhost", port=1337, network=Network.TESTNET)
 
     check_chain_context(chain_context)
 

--- a/integration-test/test/base.py
+++ b/integration-test/test/base.py
@@ -3,11 +3,10 @@
 import os
 import time
 
+from ogmios import OgmiosChainContext
 from retry import retry
 
 from pycardano import *
-
-from ogmios import OgmiosChainContext
 
 TEST_RETRIES = 6
 
@@ -24,7 +23,9 @@ class TestBase:
     # TODO: Bring back kupo test
     KUPO_URL = "http://localhost:1442"
 
-    chain_context = OgmiosChainContext(host="localhost", port=1337, network=Network.TESTNET)
+    chain_context = OgmiosChainContext(
+        host="localhost", port=1337, network=Network.TESTNET
+    )
 
     check_chain_context(chain_context)
 

--- a/integration-test/test/base.py
+++ b/integration-test/test/base.py
@@ -1,9 +1,8 @@
 """An example that demonstrates low-level construction of a transaction."""
 
 import os
-import time
 
-from ogmios import OgmiosChainContext
+import ogmios as python_ogmios
 from retry import retry
 
 from pycardano import *
@@ -23,7 +22,7 @@ class TestBase:
     # TODO: Bring back kupo test
     KUPO_URL = "http://localhost:1442"
 
-    chain_context = OgmiosChainContext(
+    chain_context = python_ogmios.OgmiosChainContext(
         host="localhost", port=1337, network=Network.TESTNET
     )
 

--- a/integration-test/test/test_cardano_cli.py
+++ b/integration-test/test/test_cardano_cli.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+
 from retry import retry
 
 from pycardano import (

--- a/integration-test/test/test_ogmios.py
+++ b/integration-test/test/test_ogmios.py
@@ -10,5 +10,4 @@ class TestProtocolParam(TestBase):
 
         cost_models = protocol_param.cost_models
         for _, cost_model in cost_models.items():
-            assert "addInteger-cpu-arguments-intercept" in cost_model
-            assert "addInteger-cpu-arguments-slope" in cost_model
+            assert len(cost_model) > 0

--- a/integration-test/test/test_plutus.py
+++ b/integration-test/test/test_plutus.py
@@ -370,10 +370,10 @@ class TestPlutus(TestBase):
         assert utxos[0].output.script == forty_two_script
 
 
-class TestPlutusOgmiosOnly(TestPlutus):
-    @classmethod
-    def setup_class(cls):
-        cls.chain_context._kupo_url = None
+# class TestPlutusOgmiosOnly(TestPlutus):
+#     @classmethod
+#     def setup_class(cls):
+#         cls.chain_context._kupo_url = None
 
 
 def evaluate_tx(tx: Transaction) -> Dict[str, ExecutionUnits]:

--- a/pycardano/backend/cardano_cli.py
+++ b/pycardano/backend/cardano_cli.py
@@ -258,6 +258,11 @@ class CardanoCliChainContext(ChainContext):
         elif "PlutusV2" in cli_cost_models:
             cost_models["PlutusV2"] = cli_cost_models["PlutusV2"].copy()
 
+        # After 8.x.x, cardano-cli returns cost models as a list
+        for m in cost_models:
+            if isinstance(cost_models[m], list):
+                cost_models[m] = {i: v for i, v in enumerate(cost_models[m])}
+
         return cost_models
 
     def _is_chain_tip_updated(self):

--- a/test/pycardano/backend/test_cardano_cli.py
+++ b/test/pycardano/backend/test_cardano_cli.py
@@ -598,7 +598,15 @@ class TestCardanoCliChainContext:
                 coins_per_utxo_byte=QUERY_PROTOCOL_PARAMETERS_RESULT.get(
                     "coinsPerUtxoByte", 0
                 ),
-                cost_models=QUERY_PROTOCOL_PARAMETERS_RESULT["costModels"],
+                cost_models={
+                    l: {
+                        i: v
+                        for i, v in enumerate(
+                            QUERY_PROTOCOL_PARAMETERS_RESULT["costModels"][l]
+                        )
+                    }
+                    for l in QUERY_PROTOCOL_PARAMETERS_RESULT["costModels"]
+                },
             )
             == chain_context.protocol_param
         )


### PR DESCRIPTION
This commit made a few changes:
1. Upgrade cardano-node version to v8.x.x from v1.x.x. This will help with testing when entering Chang hardfork.
2. Upgrade ogmios to 6.x.x because of change 1.
3. Replace built-in ogmios chain context with https://gitlab.com/viperscience/ogmios-python because of change 2.
4. Temporarily disable Kupo in integration test because ogmios-python doesn't support kupo yet.