### PR TITLE
Handle utxoCostPerByte vs coinsPerUtxoByte in cardano-cli chain context protocol params

### DIFF
--- a/integration-test/test/test_cardano_cli.py
+++ b/integration-test/test/test_cardano_cli.py
@@ -40,6 +40,7 @@ class TestCardanoCli:
 
         assert protocol_param is not None
         assert isinstance(protocol_param, ProtocolParameters)
+        assert protocol_param.coins_per_utxo_byte is not None
 
         cost_models = protocol_param.cost_models
         for cost_model in cost_models.items():

--- a/pycardano/backend/cardano_cli.py
+++ b/pycardano/backend/cardano_cli.py
@@ -311,7 +311,7 @@ class CardanoCliChainContext(ChainContext):
             ),
             coins_per_utxo_byte=result["coinsPerUtxoByte"]
             if "coinsPerUtxoByte" in result
-            else result["utxoCostPerByte"],
+            else result.get("utxoCostPerByte", 0),
             cost_models=self._parse_cost_models(result),
         )
 

--- a/pycardano/backend/cardano_cli.py
+++ b/pycardano/backend/cardano_cli.py
@@ -311,7 +311,7 @@ class CardanoCliChainContext(ChainContext):
             ),
             coins_per_utxo_byte=result["coinsPerUtxoByte"]
             if "coinsPerUtxoByte" in result
-            else result.get("utxoCostPerByte", 0),
+            else result.get("utxoCostPerByte", 0) or 0,
             cost_models=self._parse_cost_models(result),
         )
 

--- a/pycardano/backend/cardano_cli.py
+++ b/pycardano/backend/cardano_cli.py
@@ -237,11 +237,8 @@ class CardanoCliChainContext(ChainContext):
             and params["lovelacePerUTxOWord"] is not None
         ):
             return params["lovelacePerUTxOWord"]
-        elif "utxoCostPerWord" in params and params["utxoCostPerWord"] is not None:
-            return params["utxoCostPerWord"]
-        elif "utxoCostPerByte" in params and params["utxoCostPerByte"] is not None:
-            return params["utxoCostPerByte"]
-        raise ValueError("Cannot determine minUTxOValue, invalid protocol params")
+        else:
+            return 0
 
     @staticmethod
     def _parse_cost_models(cli_result: JsonDict) -> Dict[str, Dict[str, int]]:
@@ -312,7 +309,9 @@ class CardanoCliChainContext(ChainContext):
             coins_per_utxo_word=result.get(
                 "coinsPerUtxoWord", ALONZO_COINS_PER_UTXO_WORD
             ),
-            coins_per_utxo_byte=result.get("coinsPerUtxoByte", 0),
+            coins_per_utxo_byte=result["coinsPerUtxoByte"]
+            if "coinsPerUtxoByte" in result
+            else result["utxoCostPerByte"],
             cost_models=self._parse_cost_models(result),
         )
 

--- a/test/pycardano/backend/test_cardano_cli.py
+++ b/test/pycardano/backend/test_cardano_cli.py
@@ -561,7 +561,11 @@ class TestCardanoCliChainContext:
                 protocol_minor_version=int(
                     QUERY_PROTOCOL_PARAMETERS_RESULT["protocolVersion"]["minor"]
                 ),
-                min_utxo=QUERY_PROTOCOL_PARAMETERS_RESULT["utxoCostPerByte"],
+                min_utxo=QUERY_PROTOCOL_PARAMETERS_RESULT.get(
+                    "minUTxOValue",
+                    QUERY_PROTOCOL_PARAMETERS_RESULT.get("lovelacePerUTxOWord", 0),
+                )
+                or 0,
                 min_pool_cost=QUERY_PROTOCOL_PARAMETERS_RESULT["minPoolCost"],
                 price_mem=float(
                     QUERY_PROTOCOL_PARAMETERS_RESULT["executionUnitPrices"][
@@ -596,7 +600,8 @@ class TestCardanoCliChainContext:
                     "coinsPerUtxoWord", ALONZO_COINS_PER_UTXO_WORD
                 ),
                 coins_per_utxo_byte=QUERY_PROTOCOL_PARAMETERS_RESULT.get(
-                    "coinsPerUtxoByte", 0
+                    "coinsPerUtxoByte",
+                    QUERY_PROTOCOL_PARAMETERS_RESULT.get("utxoCostPerByte", 0),
                 ),
                 cost_models={
                     l: {


### PR DESCRIPTION
This is the fix for #350 