### PR TITLE
Cannot init blockfrost chain context

### DIFF
--- a/pycardano/backend/blockfrost.py
+++ b/pycardano/backend/blockfrost.py
@@ -90,7 +90,7 @@ class BlockFrostChainContext(ChainContext):
         )
 
         # Set network value to mainnet if base_url contains "mainnet".
-        if "mainnet" in self._base_url.value:
+        if "mainnet" in self._base_url:
             self._network = Network.MAINNET
 
         self.api = BlockFrostApi(project_id=self._project_id, base_url=self._base_url)

--- a/test/pycardano/backend/test_blockfrost.py
+++ b/test/pycardano/backend/test_blockfrost.py
@@ -1,29 +1,22 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from blockfrost import ApiUrls
 
-from pycardano.network import Network
 from pycardano.backend.blockfrost import BlockFrostChainContext
+from pycardano.network import Network
+
 
 @patch("pycardano.backend.blockfrost.BlockFrostApi")
 def test_blockfrost_chain_context(mock_api):
     mock_api.return_value = MagicMock()
-    chain_context = BlockFrostChainContext(
-        "project_id", base_url=ApiUrls.mainnet.value
-    )
+    chain_context = BlockFrostChainContext("project_id", base_url=ApiUrls.mainnet.value)
     assert chain_context.network == Network.MAINNET
 
-    chain_context = BlockFrostChainContext(
-        "project_id", base_url=ApiUrls.testnet.value
-    )
+    chain_context = BlockFrostChainContext("project_id", base_url=ApiUrls.testnet.value)
     assert chain_context.network == Network.TESTNET
 
-    chain_context = BlockFrostChainContext(
-        "project_id", base_url=ApiUrls.preprod.value
-    )
+    chain_context = BlockFrostChainContext("project_id", base_url=ApiUrls.preprod.value)
     assert chain_context.network == Network.TESTNET
 
-    chain_context = BlockFrostChainContext(
-        "project_id", base_url=ApiUrls.preview.value
-    )
+    chain_context = BlockFrostChainContext("project_id", base_url=ApiUrls.preview.value)
     assert chain_context.network == Network.TESTNET

--- a/test/pycardano/backend/test_blockfrost.py
+++ b/test/pycardano/backend/test_blockfrost.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch, MagicMock
+
+from blockfrost import ApiUrls
+
+from pycardano.network import Network
+from pycardano.backend.blockfrost import BlockFrostChainContext
+
+@patch("pycardano.backend.blockfrost.BlockFrostApi")
+def test_blockfrost_chain_context(mock_api):
+    mock_api.return_value = MagicMock()
+    chain_context = BlockFrostChainContext(
+        "project_id", base_url=ApiUrls.mainnet.value
+    )
+    assert chain_context.network == Network.MAINNET
+
+    chain_context = BlockFrostChainContext(
+        "project_id", base_url=ApiUrls.testnet.value
+    )
+    assert chain_context.network == Network.TESTNET
+
+    chain_context = BlockFrostChainContext(
+        "project_id", base_url=ApiUrls.preprod.value
+    )
+    assert chain_context.network == Network.TESTNET
+
+    chain_context = BlockFrostChainContext(
+        "project_id", base_url=ApiUrls.preview.value
+    )
+    assert chain_context.network == Network.TESTNET


### PR DESCRIPTION
fixed: https://github.com/Python-Cardano/pycardano/pull/353

This one should be `str` as defined in the function description.
i cannot initialize the blockfrost chain context due to the recent change:

base_url: Optional[str] = None
...
self._base_url = (base_url) ==> base_url
....
 if "mainnet" in self._base_url.value:
            self._network = Network.MAINNET


self._base_url is str then cannot have attr value (maybe enum item i think) so cannot init the context properly