### PR TITLE
Added RawPlutusData to PlutusData primitive types

### DIFF
--- a/pycardano/plutus.py
+++ b/pycardano/plutus.py
@@ -548,7 +548,15 @@ class PlutusData(ArrayCBORSerializable):
         return getattr(cls, k)
 
     def __post_init__(self):
-        valid_types = (PlutusData, dict, IndefiniteList, int, ByteString, bytes)
+        valid_types = (
+            RawPlutusData,
+            PlutusData,
+            dict,
+            IndefiniteList,
+            int,
+            ByteString,
+            bytes,
+        )
         for f in fields(self):
             if inspect.isclass(f.type) and not issubclass(f.type, valid_types):
                 raise TypeError(

--- a/test/pycardano/test_plutus.py
+++ b/test/pycardano/test_plutus.py
@@ -490,3 +490,33 @@ def test_plutus_data_long_bytes():
     assert (
         A_tmp.to_cbor_hex() == quote_hex
     ), "Long metadata bytestring is encoded incorrectly."
+
+
+def test_plutus_raw_plutus_data():
+
+    @dataclass
+    class A(PlutusData):
+        CONSTR_ID = 0
+        payload: bytes
+
+    @dataclass
+    class B(PlutusData):
+        CONSTR_ID = 0
+
+        a: A
+        b: RawPlutusData
+        c: int
+        d: RawPlutusData
+        e: RawPlutusData
+        f: Union[RawPlutusData, bytes]
+
+    cbor = (
+        "d8799fd8799f581c2f36866691fa75a9aab66dec99f7cc2d297ca09e34d9ce68cde04773ffd879"
+        + "9f581cf0e17b51bc18962397450eb625222bce9c510cb82b213bd9cf17ea82ff1a0007a120d8"
+        + "799fd8799fd8799f581ce0b68e229f9c043ab610067ed7f3c6d662b8f3c6bb4ec452c11f6411"
+        + "ffd8799fd8799fd8799f581cf0e17b51bc18962397450eb625222bce9c510cb82b213bd9cf17"
+        + "ea82ffffffffd87980ffd87a9f9f40401a00989680ff9f581c9a9693a9a37912a5097918f979"
+        + "18d15240c92ab729a0b7c4aa144d774653554e4441451a1d5a82fdffff43d87980ff"
+    )
+
+    assert B.from_cbor(cbor).to_cbor_hex() == cbor


### PR DESCRIPTION
Some contracts are starting to include forward datums, where a field could contain an arbitrary datum that will be passed on to a subsequent address.

This requires the ability to support arbitrary plutusdata.

In Python <= 3.10, it was possible to pass in `typing.Any` to a field, but starting in `Python 3.11` and beyond, it is no longer possible.

This PR adds `RawPlutusData` to the list of available of PlutusData primitives that can be used for a field.