### PR TITLE
Disable state logging in build_and_sign

### DIFF
--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -1358,7 +1358,6 @@ class TransactionBuilder:
 
         return self.context.evaluate_tx(tx)
 
-    @log_state
     def build_and_sign(
         self,
         signing_keys: List[Union[SigningKey, ExtendedSigningKey]],


### PR DESCRIPTION
Most of times error will be raised from build(), hence logging state from build_and_sign is redundant.