### PR TITLE
Automatically reduce 0 and empty multiassets

### DIFF
--- a/integration-test/test/test_zero_empty_asset.py
+++ b/integration-test/test/test_zero_empty_asset.py
@@ -149,7 +149,9 @@ class TestZeroEmptyAsset(TestBase):
             address,
             Value(
                 min_val,
-                MultiAsset.from_primitive({policy_vkey.hash().payload: {b"MY_NFT_1": 0}}),
+                MultiAsset.from_primitive(
+                    {policy_vkey.hash().payload: {b"MY_NFT_1": 0}}
+                ),
             ),
         )
         builder.add_output(nft_output)
@@ -182,7 +184,8 @@ class TestZeroEmptyAsset(TestBase):
 
         # Send the NFT to our own address
         nft_output = TransactionOutput(
-            address, Value(min_val, MultiAsset.from_primitive({policy_vkey.hash().payload: {}}))
+            address,
+            Value(min_val, MultiAsset.from_primitive({policy_vkey.hash().payload: {}})),
         )
         builder.add_output(nft_output)
 

--- a/integration-test/test/test_zero_empty_asset.py
+++ b/integration-test/test/test_zero_empty_asset.py
@@ -158,7 +158,7 @@ class TestZeroEmptyAsset(TestBase):
 
         # Build and sign transaction
         signed_tx = builder.build_and_sign(
-            [self.payment_skey, self.extended_payment_skey, policy_skey], address
+            [self.payment_skey, self.extended_payment_skey], address
         )
 
         print("############### Transaction created ###############")
@@ -191,7 +191,7 @@ class TestZeroEmptyAsset(TestBase):
 
         # Build and sign transaction
         signed_tx = builder.build_and_sign(
-            [self.payment_skey, self.extended_payment_skey, policy_skey], address
+            [self.payment_skey, self.extended_payment_skey], address
         )
 
         print("############### Transaction created ###############")

--- a/integration-test/test/test_zero_empty_asset.py
+++ b/integration-test/test/test_zero_empty_asset.py
@@ -1,0 +1,114 @@
+import pathlib
+import tempfile
+from dataclasses import dataclass
+
+import cbor2
+import pytest
+from retry import retry
+
+from pycardano import *
+
+from .base import TEST_RETRIES, TestBase
+
+
+class TestZeroEmptyAsset(TestBase):
+    @retry(tries=TEST_RETRIES, backoff=1.5, delay=6, jitter=(0, 4))
+    def test_submit_zero_and_empty(self):
+        address = Address(self.payment_vkey.hash(), network=self.NETWORK)
+
+        # Load payment keys or create them if they don't exist
+        def load_or_create_key_pair(base_dir, base_name):
+            skey_path = base_dir / f"{base_name}.skey"
+            vkey_path = base_dir / f"{base_name}.vkey"
+
+            if skey_path.exists():
+                skey = PaymentSigningKey.load(str(skey_path))
+                vkey = PaymentVerificationKey.from_signing_key(skey)
+            else:
+                key_pair = PaymentKeyPair.generate()
+                key_pair.signing_key.save(str(skey_path))
+                key_pair.verification_key.save(str(vkey_path))
+                skey = key_pair.signing_key
+                vkey = key_pair.verification_key
+            return skey, vkey
+
+        tempdir = tempfile.TemporaryDirectory()
+        PROJECT_ROOT = tempdir.name
+
+        root = pathlib.Path(PROJECT_ROOT)
+        # Create the directory if it doesn't exist
+        root.mkdir(parents=True, exist_ok=True)
+        """Generate keys"""
+        key_dir = root / "keys"
+        key_dir.mkdir(exist_ok=True)
+
+        # Generate policy keys, which will be used when minting NFT
+        policy_skey, policy_vkey = load_or_create_key_pair(key_dir, "policy")
+
+        """Build transaction"""
+
+        # Create a transaction builder
+        builder = TransactionBuilder(self.chain_context)
+
+        # Add our own address as the input address
+        builder.add_input_address(address)
+
+        # Calculate the minimum amount of lovelace that need to hold the NFT we are going to mint
+        min_val = min_lovelace_pre_alonzo(Value(0), self.chain_context)
+
+        # Send the NFT to our own address
+        nft_output = TransactionOutput(
+            address,
+            Value(
+                min_val,
+                MultiAsset.from_primitive({policy_skey.hash(): {b"MY_NFT_1": 0}}),
+            ),
+        )
+        builder.add_output(nft_output)
+
+        # Build and sign transaction
+        signed_tx = builder.build_and_sign(
+            [self.payment_skey, self.extended_payment_skey, policy_skey], address
+        )
+
+        print("############### Transaction created ###############")
+        print(signed_tx)
+        print(signed_tx.to_cbor_hex())
+
+        # Submit signed transaction to the network
+        print("############### Submitting transaction ###############")
+        self.chain_context.submit_tx(signed_tx)
+
+        self.assert_output(address, nft_output)
+
+        """Build transaction"""
+
+        # Create a transaction builder
+        builder = TransactionBuilder(self.chain_context)
+
+        # Add our own address as the input address
+        builder.add_input_address(address)
+
+        # Calculate the minimum amount of lovelace that need to hold the NFT we are going to mint
+        min_val = min_lovelace_pre_alonzo(Value(0), self.chain_context)
+
+        # Send the NFT to our own address
+        nft_output = TransactionOutput(
+            address, Value(min_val, MultiAsset.from_primitive({policy_skey.hash(): {}}))
+        )
+        builder.add_output(nft_output)
+
+        # Build and sign transaction
+        signed_tx = builder.build_and_sign(
+            [self.payment_skey, self.extended_payment_skey, policy_skey], address
+        )
+
+        print("############### Transaction created ###############")
+        print(signed_tx)
+        print(signed_tx.to_cbor_hex())
+
+        # Submit signed transaction to the network
+        print("############### Submitting transaction ###############")
+        self.chain_context.submit_tx(signed_tx)
+
+        self.assert_output(address, nft_output)

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -38,13 +38,13 @@ from pycardano.plutus import (
 from pycardano.serialization import (
     ArrayCBORSerializable,
     CBORSerializable,
+    DictBase,
     DictCBORSerializable,
     MapCBORSerializable,
     Primitive,
     default_encoder,
-    list_hook,
-    DictBase,
     limit_primitive_type,
+    list_hook,
 )
 from pycardano.types import typechecked
 from pycardano.witness import TransactionWitnessSet

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -169,7 +169,6 @@ class MultiAsset(DictCBORSerializable):
                 self.pop(k)
         return self
 
-
     def __add__(self, other):
         new_multi_asset = deepcopy(self)
         for p in other:
@@ -262,7 +261,6 @@ class MultiAsset(DictCBORSerializable):
     def to_primitive(self) -> Primitive:
         x = deepcopy(self).normalize()
         return super(self.__class__, x).to_shallow_primitive()
-
 
 
 @typechecked

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -42,7 +42,9 @@ from pycardano.serialization import (
     MapCBORSerializable,
     Primitive,
     default_encoder,
-    list_hook, DictBase, limit_primitive_type,
+    list_hook,
+    DictBase,
+    limit_primitive_type,
 )
 from pycardano.types import typechecked
 from pycardano.witness import TransactionWitnessSet
@@ -145,7 +147,6 @@ class Asset(DictCBORSerializable):
             if v == 0:
                 res.pop(n)
         return res
-
 
 
 @typechecked

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -147,10 +147,6 @@ class Asset(DictCBORSerializable):
         x = deepcopy(self).normalize()
         return super(self.__class__, x).to_shallow_primitive()
 
-    def to_primitive(self) -> Primitive:
-        x = deepcopy(self).normalize()
-        return super(self.__class__, x).to_shallow_primitive()
-
 
 @typechecked
 class MultiAsset(DictCBORSerializable):
@@ -255,10 +251,6 @@ class MultiAsset(DictCBORSerializable):
         return res
 
     def to_shallow_primitive(self) -> dict:
-        x = deepcopy(self).normalize()
-        return super(self.__class__, x).to_shallow_primitive()
-
-    def to_primitive(self) -> Primitive:
         x = deepcopy(self).normalize()
         return super(self.__class__, x).to_shallow_primitive()
 

--- a/pycardano/utils.py
+++ b/pycardano/utils.py
@@ -184,7 +184,7 @@ def min_lovelace_pre_alonzo(
         int: Minimum required lovelace amount for this transaction output.
     """
     if amount is None or isinstance(amount, int) or not amount.multi_asset:
-        return context.protocol_param.min_utxo
+        return context.protocol_param.min_utxo or 1_000_000
 
     b_size = bundle_size(amount.multi_asset)
     utxo_entry_size = 27

--- a/test/pycardano/test_transaction.py
+++ b/test/pycardano/test_transaction.py
@@ -483,26 +483,53 @@ def test_out_of_bound_asset():
     with pytest.raises(InvalidDataException):
         tx.to_cbor_hex()
 
+
 def test_zero_value():
     nft_output = Value(
         10000000,
-        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {b'MY_NFT_1': 0}}),
+        MultiAsset.from_primitive(
+            {
+                bytes.fromhex(
+                    "a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe"
+                ): {b"MY_NFT_1": 0}
+            }
+        ),
     )
     assert len(nft_output.multi_asset) == 0
+
 
 def test_empty_multiasset():
     nft_output = Value(
         10000000,
-        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {}}),
+        MultiAsset.from_primitive(
+            {
+                bytes.fromhex(
+                    "a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe"
+                ): {}
+            }
+        ),
     )
     assert len(nft_output.multi_asset) == 0
+
 
 def test_add_empty():
     nft_output = Value(
         10000000,
-        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {b'MY_NFT_1': 100}}),
+        MultiAsset.from_primitive(
+            {
+                bytes.fromhex(
+                    "a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe"
+                ): {b"MY_NFT_1": 100}
+            }
+        ),
     ) - Value(
         5,
-        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {b'MY_NFT_1': 100}}),
+        MultiAsset.from_primitive(
+            {
+                bytes.fromhex(
+                    "a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe"
+                ): {b"MY_NFT_1": 100}
+            }
+        ),
     )
     assert len(nft_output.multi_asset) == 0

--- a/test/pycardano/test_transaction.py
+++ b/test/pycardano/test_transaction.py
@@ -482,3 +482,27 @@ def test_out_of_bound_asset():
     # Not okay only when minting
     with pytest.raises(InvalidDataException):
         tx.to_cbor_hex()
+
+def test_zero_value():
+    nft_output = Value(
+        10000000,
+        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {b'MY_NFT_1': 0}}),
+    )
+    assert len(nft_output.multi_asset) == 0
+
+def test_empty_multiasset():
+    nft_output = Value(
+        10000000,
+        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {}}),
+    )
+    assert len(nft_output.multi_asset) == 0
+
+def test_add_empty():
+    nft_output = Value(
+        10000000,
+        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {b'MY_NFT_1': 100}}),
+    ) - Value(
+        5,
+        MultiAsset.from_primitive({bytes.fromhex('a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe'): {b'MY_NFT_1': 100}}),
+    )
+    assert len(nft_output.multi_asset) == 0

--- a/test/pycardano/test_transaction.py
+++ b/test/pycardano/test_transaction.py
@@ -534,15 +534,12 @@ def test_add_empty():
     )
     assert len(nft_output.multi_asset) == 0
 
+
 def test_zero_value_pop():
     policy = bytes.fromhex("a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe")
     nft_output = Value(
         10000000,
-        MultiAsset.from_primitive(
-            {
-                policy: {b"MY_NFT_1": 0, b"MY_NFT_2": 1}
-            }
-        ),
+        MultiAsset.from_primitive({policy: {b"MY_NFT_1": 0, b"MY_NFT_2": 1}}),
     )
     assert len(nft_output.multi_asset) == 1
     assert len(nft_output.multi_asset[ScriptHash(policy)]) == 1
@@ -558,7 +555,7 @@ def test_empty_multiasset_pop():
                 ): {},
                 bytes.fromhex(
                     "b39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe"
-                ): {b"MY_NFT_1": 1}
+                ): {b"MY_NFT_1": 1},
             }
         ),
     )
@@ -569,18 +566,10 @@ def test_add_empty_pop():
     policy = bytes.fromhex("a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe")
     nft_output = Value(
         10000000,
-        MultiAsset.from_primitive(
-            {
-                policy: {b"MY_NFT_1": 100, b"MY_NFT_2": 100}
-            }
-        ),
+        MultiAsset.from_primitive({policy: {b"MY_NFT_1": 100, b"MY_NFT_2": 100}}),
     ) - Value(
         5,
-        MultiAsset.from_primitive(
-            {
-                policy: {b"MY_NFT_1": 100}
-            }
-        ),
+        MultiAsset.from_primitive({policy: {b"MY_NFT_1": 100}}),
     )
     assert len(nft_output.multi_asset) == 1
     assert len(nft_output.multi_asset[ScriptHash(policy)]) == 1

--- a/test/pycardano/test_transaction.py
+++ b/test/pycardano/test_transaction.py
@@ -533,3 +533,54 @@ def test_add_empty():
         ),
     )
     assert len(nft_output.multi_asset) == 0
+
+def test_zero_value_pop():
+    policy = bytes.fromhex("a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe")
+    nft_output = Value(
+        10000000,
+        MultiAsset.from_primitive(
+            {
+                policy: {b"MY_NFT_1": 0, b"MY_NFT_2": 1}
+            }
+        ),
+    )
+    assert len(nft_output.multi_asset) == 1
+    assert len(nft_output.multi_asset[ScriptHash(policy)]) == 1
+
+
+def test_empty_multiasset_pop():
+    nft_output = Value(
+        10000000,
+        MultiAsset.from_primitive(
+            {
+                bytes.fromhex(
+                    "a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe"
+                ): {},
+                bytes.fromhex(
+                    "b39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe"
+                ): {b"MY_NFT_1": 1}
+            }
+        ),
+    )
+    assert len(nft_output.multi_asset) == 1
+
+
+def test_add_empty_pop():
+    policy = bytes.fromhex("a39a5998f2822dfc9111e447038c3cfffa883ed1b9e357be9cd60dfe")
+    nft_output = Value(
+        10000000,
+        MultiAsset.from_primitive(
+            {
+                policy: {b"MY_NFT_1": 100, b"MY_NFT_2": 100}
+            }
+        ),
+    ) - Value(
+        5,
+        MultiAsset.from_primitive(
+            {
+                policy: {b"MY_NFT_1": 100}
+            }
+        ),
+    )
+    assert len(nft_output.multi_asset) == 1
+    assert len(nft_output.multi_asset[ScriptHash(policy)]) == 1

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -1202,6 +1202,7 @@ def test_build_and_sign(chain_context):
     tx = tx_builder2.build_and_sign(
         [SK],
         change_address=sender_address,
+        force_skeys=True,
     )
 
     assert tx.transaction_witness_set.vkey_witnesses == [

--- a/test/pycardano/test_util.py
+++ b/test/pycardano/test_util.py
@@ -88,7 +88,8 @@ class TestMinLoveLaceMultiAsset:
                 {
                     b"1"
                     * SCRIPT_HASH_SIZE: {
-                        i.to_bytes(1, byteorder="big"): 1000000 * i for i in range(1, 33)
+                        i.to_bytes(1, byteorder="big"): 1000000 * i
+                        for i in range(1, 33)
                     },
                     b"2"
                     * SCRIPT_HASH_SIZE: {

--- a/test/pycardano/test_util.py
+++ b/test/pycardano/test_util.py
@@ -88,7 +88,7 @@ class TestMinLoveLaceMultiAsset:
                 {
                     b"1"
                     * SCRIPT_HASH_SIZE: {
-                        i.to_bytes(1, byteorder="big"): 1000000 * i for i in range(32)
+                        i.to_bytes(1, byteorder="big"): 1000000 * i for i in range(1, 33)
                     },
                     b"2"
                     * SCRIPT_HASH_SIZE: {


### PR DESCRIPTION
I noticed that the new ledger rules now disallow empty dicts and 0 values in multiassets. It would be good to anyways prevent this by design - this also always makes transactions cheaper. Here is an implementation proposal. I also tried to verify the non-emptiness strictness with an integration test but it seems to fail. We may want to remove it.