### PR TITLE
Fixed transaction imbalance when burning assets from the same policy

### DIFF
--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -107,7 +107,7 @@ class Asset(DictCBORSerializable):
 
     def __iadd__(self, other: Asset) -> Asset:
         new_item = self + other
-        self.update(new_item)
+        self.data = new_item.data
         return self.normalize()
 
     def __sub__(self, other: Asset) -> Asset:
@@ -173,7 +173,7 @@ class MultiAsset(DictCBORSerializable):
 
     def __iadd__(self, other):
         new_item = self + other
-        self.update(new_item)
+        self.data = new_item.data
         return self.normalize()
 
     def __sub__(self, other: MultiAsset) -> MultiAsset:

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -548,7 +548,26 @@ class TransactionBuilder:
         for i in inputs:
             provided += i.output.amount
         if self.mint:
-            provided.multi_asset += self.mint
+            for policy_id, assets in self.mint.items():
+                for asset_name, quantity in assets.items():
+                    provided.multi_asset[policy_id][asset_name] += quantity
+
+            for policy_id in list(provided.multi_asset.keys()):
+                new_asset = Asset(
+                    {
+                        asset_name: quantity
+                        for asset_name, quantity in provided.multi_asset[
+                            policy_id
+                        ].items()
+                        if quantity != 0
+                    }
+                )
+
+                if new_asset:
+                    provided.multi_asset[policy_id] = new_asset
+                else:
+                    del provided.multi_asset[policy_id]
+
         if self.withdrawals:
             for v in self.withdrawals.values():
                 provided.coin += v

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -559,22 +559,6 @@ class TransactionBuilder:
 
                     provided.multi_asset[policy_id][asset_name] += quantity
 
-            for policy_id in list(provided.multi_asset.keys()):
-                new_asset = Asset(
-                    {
-                        asset_name: quantity
-                        for asset_name, quantity in provided.multi_asset[
-                            policy_id
-                        ].items()
-                        if quantity != 0
-                    }
-                )
-
-                if new_asset:
-                    provided.multi_asset[policy_id] = new_asset
-                else:
-                    del provided.multi_asset[policy_id]
-
         if self.withdrawals:
             for v in self.withdrawals.values():
                 provided.coin += v

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -549,15 +549,7 @@ class TransactionBuilder:
             provided += i.output.amount
 
         if self.mint:
-            for policy_id, assets in self.mint.items():
-                for asset_name, quantity in assets.items():
-                    if policy_id not in provided.multi_asset:
-                        provided.multi_asset[policy_id] = Asset()
-
-                    if asset_name not in provided.multi_asset[policy_id]:
-                        provided.multi_asset[policy_id][asset_name] = 0
-
-                    provided.multi_asset[policy_id][asset_name] += quantity
+            provided.multi_asset += self.mint
 
         if self.withdrawals:
             for v in self.withdrawals.values():

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -547,9 +547,16 @@ class TransactionBuilder:
         provided = Value()
         for i in inputs:
             provided += i.output.amount
+
         if self.mint:
             for policy_id, assets in self.mint.items():
                 for asset_name, quantity in assets.items():
+                    if policy_id not in provided.multi_asset:
+                        provided.multi_asset[policy_id] = Asset()
+
+                    if asset_name not in provided.multi_asset[policy_id]:
+                        provided.multi_asset[policy_id][asset_name] = 0
+
                     provided.multi_asset[policy_id][asset_name] += quantity
 
             for policy_id in list(provided.multi_asset.keys()):

--- a/pycardano/witness.py
+++ b/pycardano/witness.py
@@ -8,17 +8,17 @@ from typing import Any, List, Optional, Type, Union
 from pycardano.key import ExtendedVerificationKey, VerificationKey
 from pycardano.nativescript import NativeScript
 from pycardano.plutus import (
+    ExecutionUnits,
     PlutusV1Script,
     PlutusV2Script,
     PlutusV3Script,
     RawPlutusData,
     Redeemer,
-    Redeemers,
-    RedeemerMap,
     RedeemerKey,
-    RedeemerValue,
-    ExecutionUnits,
+    RedeemerMap,
+    Redeemers,
     RedeemerTag,
+    RedeemerValue,
 )
 from pycardano.serialization import (
     ArrayCBORSerializable,

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -1933,7 +1933,7 @@ def test_transaction_witness_set_no_redeemers(chain_context):
     assert witness_set.redeemer is None
 
 
-def test_burning_assets_with_preserved_policy(chain_context):
+def test_minting_updates_multi_asset_correctly(chain_context):
     """
     Test the burning of assets under one policy ID while preserving assets under another policy ID.
 

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -1933,28 +1933,29 @@ def test_transaction_witness_set_no_redeemers(chain_context):
     assert witness_set.redeemer is None
 
 
-def test_minting_and_burning_zero_quantity_assets(chain_context):
+def test_burning_assets_with_preserved_policy(chain_context):
     """
-    Test the minting and burning of multiple assets using the TransactionBuilder.
+    Test the burning of assets under one policy ID while preserving assets under another policy ID.
 
-    This test ensures that assets are correctly minted and burned under the same policy ID.
-    Specifically, it verifies that after burning certain assets (AssetName1, AssetName2, and AssetName3),
-    they are removed from the multi-asset map, and the correct amount of the minted asset (AssetName4) remains.
+    This test ensures that assets are correctly burned under one policy (policy_id_1), while assets under another policy (policy_id_2)
+    remain unchanged. Specifically, it verifies that after burning certain assets (AssetName1, AssetName2, AssetName3, and AssetName4)
+    under policy_id_1, they are removed from the multi-asset map, while assets under policy_id_2 (AssetName5) remain intact.
 
     Steps:
-    1. Define a policy ID and several assets (AssetName1, AssetName2, AssetName3, and AssetName4) using the AssetName class.
-    2. Simulate minting of 2 units of AssetName4 and burning 1 unit each of AssetName1, AssetName2, and AssetName3.
+    1. Define two policy IDs and several assets (AssetName1, AssetName2, AssetName3, AssetName4 under policy_id_1
+       and AssetName5 under policy_id_2) using the AssetName class.
+    2. Simulate burning of 1 unit each of AssetName1, AssetName2, AssetName3, and AssetName4 under policy_id_1.
     3. Add corresponding UTXOs for each asset as inputs.
-    4. Add minting instructions to the TransactionBuilder.
+    4. Add burn instructions to the TransactionBuilder.
     5. Build the transaction and verify that the burnt assets are removed from the multi-asset map.
-    6. Check that the correct quantity of AssetName4 is minted and included in the transaction outputs.
+    6. Check that the correct quantity of AssetName5 under policy_id_2 remains intact in the transaction outputs.
 
     Args:
         chain_context: The blockchain context used for constructing and verifying the transaction.
 
     Assertions:
-        - AssetName1, AssetName2, and AssetName3 are not present in the multi-asset map after burning.
-        - AssetName4 has exactly 2 units minted.
+        - AssetName1, AssetName2, AssetName3, and AssetName4 (under policy_id_1) are not present in the multi-asset map after burning.
+        - AssetName5 (under policy_id_2) remains with exactly 20 units in the transaction outputs.
     """
     tx_builder = TransactionBuilder(chain_context)
 
@@ -1976,43 +1977,51 @@ def test_minting_and_burning_zero_quantity_assets(chain_context):
         ["d6cbe6cadecd3f89b60e08e68e5e6c7d72d730aaa1ad21431590f7e6643438ef", 3]
     )
     # Define a policy ID and asset names
-    policy_id = plutus_script_hash(PlutusV1Script(b"dummy script"))
-    multi_asset1 = MultiAsset.from_primitive({policy_id.payload: {b"AssetName1": 1}})
-    multi_asset2 = MultiAsset.from_primitive({policy_id.payload: {b"AssetName2": 2}})
-    multi_asset3 = MultiAsset.from_primitive({policy_id.payload: {b"AssetName3": 1}})
-    multi_asset4 = MultiAsset.from_primitive({policy_id.payload: {b"AssetName4": 3}})
+    policy_id_1 = plutus_script_hash(PlutusV1Script(b"dummy script1"))
+    policy_id_2 = plutus_script_hash(PlutusV1Script(b"dummy script2"))
+    multi_asset1 = MultiAsset.from_primitive({policy_id_1.payload: {b"AssetName1": 1}})
+    multi_asset2 = MultiAsset.from_primitive({policy_id_1.payload: {b"AssetName2": 1}})
+    multi_asset3 = MultiAsset.from_primitive(
+        {
+            policy_id_1.payload: {b"AssetName3": 1},
+            policy_id_2.payload: {b"AssetName5": 10},
+        }
+    )
+    multi_asset4 = MultiAsset.from_primitive(
+        {
+            policy_id_1.payload: {b"AssetName4": 1},
+            policy_id_2.payload: {b"AssetName5": 10},
+        }
+    )
 
     # Simulate minting and burning of assets
     mint = MultiAsset.from_primitive(
         {
-            policy_id.payload: {
+            policy_id_1.payload: {
                 b"AssetName1": -1,
-                b"AssetName2": -2,
+                b"AssetName2": -1,
                 b"AssetName3": -1,
-                b"AssetName4": 2,
+                b"AssetName4": -1,
             }
         }
     )
 
     # Set UTXO for the inputs
     utxo1 = UTxO(
-        tx_in1, TransactionOutput(Address(policy_id), Value(10000000, multi_asset1))
+        tx_in1, TransactionOutput(Address(policy_id_1), Value(10000000, multi_asset1))
     )
     utxo2 = UTxO(
-        tx_in2, TransactionOutput(Address(policy_id), Value(10000000, multi_asset2))
+        tx_in2, TransactionOutput(Address(policy_id_1), Value(10000000, multi_asset2))
     )
     utxo3 = UTxO(
-        tx_in3, TransactionOutput(Address(policy_id), Value(10000000, multi_asset3))
+        tx_in3, TransactionOutput(Address(policy_id_1), Value(10000000, multi_asset3))
     )
     utxo4 = UTxO(
-        tx_in4, TransactionOutput(Address(policy_id), Value(10000000, multi_asset4))
+        tx_in4, TransactionOutput(Address(policy_id_1), Value(10000000, multi_asset4))
     )
 
     # Add UTXO inputs
-    tx_builder.add_input(utxo1)
-    tx_builder.add_input(utxo2)
-    tx_builder.add_input(utxo3)
-    tx_builder.add_input(utxo4)
+    tx_builder.add_input(utxo1).add_input(utxo2).add_input(utxo3).add_input(utxo4)
 
     # Add the minting to the builder
     tx_builder.mint = mint
@@ -2027,10 +2036,11 @@ def test_minting_and_burning_zero_quantity_assets(chain_context):
     for output in tx.outputs:
         multi_asset = output.amount.multi_asset
 
-        # Ensure that AssetName1, Node2, and Node3 were burnt (removed)
-        assert AssetName(b"AssetName1") not in multi_asset.get(policy_id, {})
-        assert AssetName(b"AssetName2") not in multi_asset.get(policy_id, {})
-        assert AssetName(b"AssetName3") not in multi_asset.get(policy_id, {})
+        # Ensure that AssetName1, AssetName2, AssetName3 and AssetName4 were burnt (removed)
+        assert AssetName(b"AssetName1") not in multi_asset.get(policy_id_1, {})
+        assert AssetName(b"AssetName2") not in multi_asset.get(policy_id_1, {})
+        assert AssetName(b"AssetName3") not in multi_asset.get(policy_id_1, {})
+        assert AssetName(b"AseetName4") not in multi_asset.get(policy_id_1, {})
 
-        # Ensure that AssetName4 has 5 units after minting
-        assert multi_asset.get(policy_id, {}).get(AssetName(b"AssetName4"), 0) == 5
+        # Ensure that 20 units of AssetName5 are retained from the input
+        assert multi_asset.get(policy_id_2, {}).get(AssetName(b"AssetName5"), 0) == 20


### PR DESCRIPTION
### Problem
The logic did not properly handle cases where assets under one policy were burned. This led to incorrect outputs in the `multi_asset` structure, causing transaction outputs to be improperly computed.

### Solution
A fix was applied to ensure proper handling of burning assets under the same policy. 
- Unite test:
   Assets that are burned under a given policy ID (`policy_id_1`) are properly removed from the `multi_asset` map.

### Changes
- In the `_calc_change` method of `txbuilder.py`.

### Additional information
Tested on [preproduction](https://preprod.cexplorer.io/tx/87375103836ea41590a54403e2c5de7dccc56d72acbae7bc58357cd02e6c9a40).
