### PR TITLE
Make vkey witnesses None when empty

### DIFF
--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -1508,4 +1508,7 @@ class TransactionBuilder:
                 VerificationKeyWitness(signing_key.to_verification_key(), signature)
             )
 
+        if len(witness_set.vkey_witnesses) == 0:
+            witness_set.vkey_witnesses = None
+
         return Transaction(tx_body, witness_set, auxiliary_data=self.auxiliary_data)


### PR DESCRIPTION
This is a minor fix to vkey witnesses when empty in the transaction builder.

When building a transaction without signing keys, the empty vkey witnesses list gets encoded to an empty value in the witness. This seems to cause an issue for some wallets.

Preferably merged into the chang branch prior to #371 