### PR TITLE
Add Transaction Metadata CBOR Retrieval Functionality

### DIFF
--- a/pycardano/backend/__init__.py
+++ b/pycardano/backend/__init__.py
@@ -3,5 +3,6 @@
 from .base import *
 from .blockfrost import *
 from .cardano_cli import *
+from .kupo import *
 from .ogmios_v5 import *
 from .ogmios_v6 import *

--- a/pycardano/backend/base.py
+++ b/pycardano/backend/base.py
@@ -11,6 +11,7 @@ from pycardano.network import Network
 from pycardano.plutus import ExecutionUnits
 from pycardano.transaction import Transaction, UTxO
 from pycardano.types import typechecked
+from pycardano.serialization import RawCBOR
 
 __all__ = [
     "GenesisParameters",
@@ -218,3 +219,20 @@ class ChainContext:
             List[ExecutionUnits]: A list of execution units calculated for each of the transaction's redeemers
         """
         raise NotImplementedError()
+
+    def tx_metadata_cbor(
+        self, tx_id: str, slot: Optional[int] = None
+    ) -> Optional[RawCBOR]:
+        """Get metadata CBOR for a transaction.
+
+        Args:
+            tx_id (str): Transaction id for metadata to query.
+            slot (Optional[int]): Slot number. Required for some backends (e.g., Kupo).
+
+        Returns:
+            Optional[RawCBOR]: Metadata CBOR if found, None otherwise.
+
+        Raises:
+            NotImplementedError: If the method is not implemented in the subclass.
+        """
+        raise NotImplementedError("tx_metadata_cbor is not implemented in the subclass")

--- a/pycardano/backend/blockfrost.py
+++ b/pycardano/backend/blockfrost.py
@@ -322,3 +322,29 @@ class BlockFrostChainContext(ChainContext):
                     getattr(result.EvaluationResult, k).steps,
                 )
             return return_val
+
+    def tx_metadata_cbor(
+        self, tx_id: str, slot: Optional[int] = None
+    ) -> Optional[RawCBOR]:
+        """Get metadata CBOR for a transaction using BlockFrost.
+
+        Args:
+            tx_id (str): Transaction id for metadata to query.
+            slot (Optional[int]): Slot number (not used in BlockFrost implementation).
+
+        Returns:
+            Optional[RawCBOR]: Metadata CBOR if found, None otherwise.
+
+        Raises:
+            :class:`ApiError`: When fails to get metadata.
+        """
+        try:
+            response = self.api.transaction_metadata_cbor(tx_id)
+            if response:
+                return RawCBOR(bytes.fromhex(response[0].metadata))
+            return None
+        except ApiError as e:
+            if e.status_code == 404:
+                return None
+            else:
+                raise e

--- a/pycardano/backend/ogmios_v6.py
+++ b/pycardano/backend/ogmios_v6.py
@@ -356,6 +356,25 @@ class OgmiosV6ChainContext(ChainContext):
                 cost_models["PlutusV3"][f"{i:0{width}d}"] = v
         return cost_models
 
+    def tx_metadata_cbor(
+        self, tx_id: str, slot: Optional[int] = None
+    ) -> Optional[RawCBOR]:
+        """Get metadata CBOR for a transaction using Ogmios.
+
+        Args:
+            tx_id (str): Transaction id for metadata to query.
+            slot (Optional[int]): Slot number (not used in Ogmios implementation).
+
+        Returns:
+            Optional[RawCBOR]: Metadata CBOR if found, None otherwise.
+
+        Raises:
+            NotImplementedError: This method is not yet implemented for Ogmios V6 backend.
+        """
+        raise NotImplementedError(
+            "get_metadata_cbor is not yet implemented for Ogmios V6 backend"
+        )
+
 
 class OgmiosChainContext(OgmiosV6ChainContext):
     """An alias of OgmiosV6ChainContext for backwards compatibility."""
@@ -373,6 +392,7 @@ def KupoOgmiosV6ChainContext(
     network: Network = Network.TESTNET,
     kupo_url: Optional[str] = None,
 ) -> KupoChainContextExtension:
+    """Create a KupoChainContextExtension with an OgmiosV6ChainContext backend and Kupo URL."""
     return KupoChainContextExtension(
         OgmiosV6ChainContext(
             host,


### PR DESCRIPTION
## Purpose
This PR introduces a new method `tx_metadata_cbor` to retrieve transaction metadata in CBOR format across different backend implementations. This feature enhances PyCardano's capabilities for querying and working with transaction metadata.

## Key Changes
1. Added a new abstract method `tx_metadata_cbor` to the base `ChainContext` class.
2. Implemented `tx_metadata_cbor` for the BlockFrost backend.
3. Implemented `tx_metadata_cbor` for the Kupo backend with caching and fallback to wrapped backend.
4. Added a placeholder implementation for the Ogmios V6 backend.
5. Updated the `__init__.py` file to include the new Kupo module.