### PR TITLE
Add path to Ogmios v6 backend

### DIFF
--- a/pycardano/backend/ogmios_v6.py
+++ b/pycardano/backend/ogmios_v6.py
@@ -368,6 +368,7 @@ class OgmiosChainContext(OgmiosV6ChainContext):
 def KupoOgmiosV6ChainContext(
     host: str,
     port: int,
+    path: str,
     secure: bool,
     refetch_chain_tip_interval: Optional[float] = None,
     utxo_cache_size: int = 10000,
@@ -379,6 +380,7 @@ def KupoOgmiosV6ChainContext(
         OgmiosV6ChainContext(
             host,
             port,
+            path,
             secure,
             refetch_chain_tip_interval,
             utxo_cache_size,

--- a/pycardano/backend/ogmios_v6.py
+++ b/pycardano/backend/ogmios_v6.py
@@ -59,6 +59,7 @@ class OgmiosV6ChainContext(ChainContext):
         self,
         host: str = "localhost",
         port: int = 1337,
+        path: str = "",
         secure: bool = False,
         refetch_chain_tip_interval: Optional[float] = None,
         utxo_cache_size: int = 10000,
@@ -67,6 +68,7 @@ class OgmiosV6ChainContext(ChainContext):
     ):
         self.host = host
         self.port = port
+        self.path = path
         self.secure = secure
         self._network = network
         self._service_name = "ogmios"
@@ -86,26 +88,26 @@ class OgmiosV6ChainContext(ChainContext):
         self._datum_cache = LRUCache(maxsize=datum_cache_size)
 
     def _query_current_era(self) -> OgmiosEra:
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             return get_current_era(client)
 
     def _query_current_epoch(self) -> int:
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             epoch, _ = client.query_epoch.execute()
             return epoch
 
     def _query_chain_tip(self) -> OgmiosTip:
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             tip, _ = client.query_network_tip.execute()
             return tip
 
     def _query_utxos_by_address(self, address: Address) -> List[OgmiosUtxo]:
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             utxos, _ = client.query_utxo.execute([address])
             return utxos
 
     def _query_utxos_by_tx_id(self, tx_id: str, index: int) -> List[OgmiosUtxo]:
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             utxos, _ = client.query_utxo.execute(
                 [OgmiosTxOutputReference(tx_id, index)]
             )
@@ -135,7 +137,7 @@ class OgmiosV6ChainContext(ChainContext):
         return self._protocol_param
 
     def _fetch_protocol_param(self) -> ProtocolParameters:
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             protocol_parameters, _ = client.query_protocol_parameters.execute()
             pyc_protocol_params = ProtocolParameters(
                 min_fee_constant=protocol_parameters.min_fee_constant.lovelace,
@@ -205,7 +207,7 @@ class OgmiosV6ChainContext(ChainContext):
         return self._genesis_param  # type: ignore[return-value]
 
     def _fetch_genesis_param(self) -> OgmiosGenesisParameters:
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             return OgmiosGenesisParameters(client, self._query_current_era())
 
     @property
@@ -263,7 +265,7 @@ class OgmiosV6ChainContext(ChainContext):
             # TODO: Need to test with native scripts
             if script["language"] == "plutus:v3":
                 script = PlutusV3Script(bytes.fromhex(script["cbor"]))
-            elif script["language"] == "plutus:v2":
+            if script["language"] == "plutus:v2":
                 script = PlutusV2Script(bytes.fromhex(script["cbor"]))
             elif script["language"] == "plutus:v1":
                 script = PlutusV1Script(bytes.fromhex(script["cbor"]))
@@ -311,13 +313,13 @@ class OgmiosV6ChainContext(ChainContext):
     def submit_tx_cbor(self, cbor: Union[bytes, str]):
         if isinstance(cbor, bytes):
             cbor = cbor.hex()
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             client.submit_transaction.execute(cbor)
 
     def evaluate_tx_cbor(self, cbor: Union[bytes, str]) -> Dict[str, ExecutionUnits]:
         if isinstance(cbor, bytes):
             cbor = cbor.hex()
-        with OgmiosClient(self.host, self.port, self.secure) as client:
+        with OgmiosClient(self.host, self.port, self.path, self.secure) as client:
             result, _ = client.evaluate_transaction.execute(cbor)
             result_dict = {}
             for res in result:

--- a/pycardano/backend/ogmios_v6.py
+++ b/pycardano/backend/ogmios_v6.py
@@ -265,7 +265,7 @@ class OgmiosV6ChainContext(ChainContext):
             # TODO: Need to test with native scripts
             if script["language"] == "plutus:v3":
                 script = PlutusV3Script(bytes.fromhex(script["cbor"]))
-            if script["language"] == "plutus:v2":
+            elif script["language"] == "plutus:v2":
                 script = PlutusV2Script(bytes.fromhex(script["cbor"]))
             elif script["language"] == "plutus:v1":
                 script = PlutusV1Script(bytes.fromhex(script["cbor"]))


### PR DESCRIPTION
A couple of months ago, I added a `path` argument to Ogmios.

https://gitlab.com/viperscience/ogmios-python/-/merge_requests/13

This PR adds support for the `path` argument in the Ogmios chain context.

For some additional context, the `path` argument allows you to specify a path in the IP/URL of the Ogmios endpoint. We had a specific use case for this where we wanted to serve Ogmios for different networks on `my.url.io/mainnet` and `my.url.io/preprod`.

I don't believe the change has been deployed on Ogmios yet, so this should be merged once that change is released.