### PR TITLE
Added IndefiniteDecoder for round trip plutusdata serialization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install
+      - name: Ensure pure cbor2 is installed
+        run: |
+          make ensure-pure-cbor2
       - name: Run unit tests
         run: |
           poetry run pytest --doctest-modules --ignore=examples --cov=pycardano --cov-config=.coveragerc --cov-report=xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install
+      - name: Ensure pure cbor2 is installed
+        run: |
+          make ensure-pure-cbor2
       - name: Lint with flake8
         run: |
           poetry run flake8 pycardano

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docs/build
 dist
 .mypy_cache
 coverage.xml
+.cbor2_version
 
 # IDE
 .idea

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,24 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := poetry run python -c "$$BROWSER_PYSCRIPT"
 
+ensure-pure-cbor2: ## ensures cbor2 is installed with pure Python implementation
+	@poetry run python -c "from importlib.metadata import version; \
+	print(version('cbor2'))" > .cbor2_version
+	@poetry run python -c "import cbor2, inspect; \
+	print('Checking cbor2 implementation...'); \
+	decoder_path = inspect.getfile(cbor2.CBORDecoder); \
+	using_c_ext = decoder_path.endswith('.so'); \
+	print(f'Implementation path: {decoder_path}'); \
+	print(f'Using C extension: {using_c_ext}'); \
+	exit(1 if using_c_ext else 0)" || \
+	(echo "Reinstalling cbor2 with pure Python implementation..." && \
+	poetry run pip install --no-binary cbor2 "cbor2==$$(cat .cbor2_version)" --force-reinstall && \
+	rm .cbor2_version)
+
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
-cov: ## check code coverage
+cov: ensure-pure-cbor2 ## check code coverage
 	poetry run pytest -n 4 --cov pycardano
 
 cov-html: cov ## check code coverage and generate an html report
@@ -54,7 +68,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr cov_html/
 	rm -fr .pytest_cache
 
-test: ## runs tests
+test: ensure-pure-cbor2 ## runs tests
 	poetry run pytest -vv -n 4
 
 test-integration: ## runs integration tests
@@ -63,7 +77,7 @@ test-integration: ## runs integration tests
 test-single: ## runs tests with "single" markers
 	poetry run pytest -s -vv -m single
 
-qa: ## runs static analyses
+qa: ensure-pure-cbor2 ## runs static analyses
 	poetry run flake8 pycardano
 	poetry run mypy --install-types --non-interactive pycardano
 	poetry run black --check .
@@ -78,6 +92,6 @@ docs: ## build the documentation
 	poetry run sphinx-build docs/source docs/build/html
 	$(BROWSER) docs/build/html/index.html
 
-release: clean qa test format ## build dist version and release to pypi
+release: clean qa test format ensure-pure-cbor2 ## build dist version and release to pypi
 	poetry build
 	poetry publish

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ ensure-pure-cbor2: ## ensures cbor2 is installed with pure Python implementation
 	print(f'Using C extension: {using_c_ext}'); \
 	exit(1 if using_c_ext else 0)" || \
 	(echo "Reinstalling cbor2 with pure Python implementation..." && \
-	poetry run pip install --no-binary cbor2 "cbor2==$$(cat .cbor2_version)" --force-reinstall && \
+	poetry run pip uninstall -y cbor2 && \
+	CBOR2_BUILD_C_EXTENSION=0 poetry run pip install --no-binary cbor2 "cbor2==$$(cat .cbor2_version)" --force-reinstall && \
 	rm .cbor2_version)
 
 help:

--- a/integration-test/run_tests.sh
+++ b/integration-test/run_tests.sh
@@ -6,6 +6,7 @@ set -o pipefail
 ROOT=$(pwd)
 
 poetry install -C ..
+make ensure-pure-cbor2 -f ../Makefile
 #poetry run pip install ogmios
 
 ##########

--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -735,8 +735,8 @@ class ArrayCBORSerializable(CBORSerializable):
         return primitives
 
     @classmethod
-    @limit_primitive_type(list, tuple)
-    def from_primitive(cls: Type[ArrayBase], values: Union[list, tuple]) -> ArrayBase:
+    @limit_primitive_type(list, tuple, IndefiniteList)
+    def from_primitive(cls: Type[ArrayBase], values: Union[list, tuple, IndefiniteList]) -> ArrayBase:
         """Restore a primitive value to its original class type.
 
         Args:

--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -49,7 +49,6 @@ from cbor2 import (
     CBORTag,
     FrozenDict,
     dumps,
-    loads,
     undefined,
 )
 from frozenlist import FrozenList
@@ -208,7 +207,9 @@ class IndefiniteDecoder(CBORDecoder):
         length = self._decode_length(subtype, allow_indefinite=True)
 
         if length is None:
-            return IndefiniteList(super().decode_array(subtype=subtype))
+            return IndefiniteList(
+                cast(Primitive, super().decode_array(subtype=subtype))
+            )
         else:
             return super().decode_array(subtype=subtype)
 
@@ -531,7 +532,7 @@ class CBORSerializable:
         if type(payload) is str:
             payload = bytes.fromhex(payload)
 
-        with BytesIO(payload) as fp:
+        with BytesIO(cast(bytes, payload)) as fp:
             value = IndefiniteDecoder(fp).decode()
 
         return cls.from_primitive(value)
@@ -555,7 +556,7 @@ def _restore_dataclass_field(
 
     if "object_hook" in f.metadata:
         return f.metadata["object_hook"](v)
-    return _restore_typed_primitive(f.type, v)
+    return _restore_typed_primitive(cast(Any, f.type), v)
 
 
 def _restore_typed_primitive(

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -30,7 +30,7 @@ from pycardano import (
     VerificationKeyWitness,
 )
 from pycardano.exception import DeserializeException, SerializeException
-from pycardano.plutus import PlutusV1Script, PlutusV2Script
+from pycardano.plutus import PlutusData, PlutusV1Script, PlutusV2Script
 from pycardano.serialization import (
     ArrayCBORSerializable,
     ByteString,
@@ -366,6 +366,31 @@ def test_unexpected_validate_type():
 
     obj = Test1(a=None, b=dq)
     obj.validate()
+
+
+@pytest.mark.xfail
+def test_datum_raw_round_trip():
+    @dataclass
+    class TestDatum(PlutusData):
+        CONSTR_ID = 0
+        a: int
+        b: List[bytes]
+
+    datum = TestDatum(a=1, b=[b"test", b"datum"])
+    restored = RawPlutusData.from_cbor(datum.to_cbor())
+    assert datum.to_cbor_hex() == restored.to_cbor_hex()
+
+
+def test_datum_round_trip():
+    @dataclass
+    class TestDatum(PlutusData):
+        CONSTR_ID = 0
+        a: int
+        b: List[bytes]
+
+    datum = TestDatum(a=1, b=[b"test", b"datum"])
+    restored = TestDatum.from_cbor(datum.to_cbor())
+    assert datum.to_cbor_hex() == restored.to_cbor_hex()
 
 
 def test_wrong_primitive_type():

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -368,7 +368,6 @@ def test_unexpected_validate_type():
     obj.validate()
 
 
-@pytest.mark.xfail
 def test_datum_raw_round_trip():
     @dataclass
     class TestDatum(PlutusData):

--- a/test/pycardano/test_transaction.py
+++ b/test/pycardano/test_transaction.py
@@ -416,6 +416,21 @@ def test_multi_asset_comparison():
     with pytest.raises(TypeCheckError):
         a <= 1
 
+def test_datum_witness():
+    @dataclass
+    class TestDatum(PlutusData):
+        CONSTR_ID = 0
+        a: int
+        b: bytes
+
+    tx_body = make_transaction_body()
+    signed_tx = Transaction(
+        tx_body,
+        TransactionWitnessSet(vkey_witnesses=None, plutus_data=[TestDatum(1, b"test")]),
+    )
+    restored_tx = Transaction.from_cbor(signed_tx.to_cbor())
+
+    assert signed_tx.to_cbor_hex() == restored_tx.to_cbor_hex()
 
 def test_values():
     a = Value.from_primitive(

--- a/test/pycardano/test_transaction.py
+++ b/test/pycardano/test_transaction.py
@@ -416,6 +416,7 @@ def test_multi_asset_comparison():
     with pytest.raises(TypeCheckError):
         a <= 1
 
+
 def test_datum_witness():
     @dataclass
     class TestDatum(PlutusData):
@@ -431,6 +432,7 @@ def test_datum_witness():
     restored_tx = Transaction.from_cbor(signed_tx.to_cbor())
 
     assert signed_tx.to_cbor_hex() == restored_tx.to_cbor_hex()
+
 
 def test_values():
     a = Value.from_primitive(


### PR DESCRIPTION
This PR adds support for IndefiniteDecoder, a special CBOR decoder class that returns indefinite lists as an `IndefiniteList` rather than a `list` as a way to support roundtrip, reproducible `PlutusData` serialization.

There are two new unit tests that demonstrate the need for this PR in the serialization tests.

The first is `test_datum_round_trip`, that creates a custom `PlutusData` class, serializes to CBOR and deserializes. Without the `IndefiniteDecoder`, this test fails.

The second test is `test_datum_raw_round_trip`, that creates a custom `Plutusdata` class, serializes to CBOR and deserializes as `RawPlutusData`. This test is currently marked as an expected fail test, since this PR does not resolve this issue. Attempts to resolve this problem causes issues with other round trip serialization tests, and warrants further investigation.

closes #331 