### PR TITLE
Fix transaction certificates in Conway and handle latest cardano-cli transaction commands

### DIFF
--- a/pycardano/backend/cardano_cli.py
+++ b/pycardano/backend/cardano_cli.py
@@ -520,22 +520,39 @@ class CardanoCliChainContext(ChainContext):
 
             try:
                 self._run_command(
-                    ["transaction", "submit", "--tx-file", tmp_tx_file.name]
+                    [
+                        "latest",
+                        "transaction",
+                        "submit",
+                        "--tx-file",
+                        tmp_tx_file.name,
+                    ]
                     + self._network_args
                 )
-            except CardanoCliError as err:
-                raise TransactionFailedException(
-                    "Failed to submit transaction"
-                ) from err
+            except CardanoCliError:
+                try:
+                    self._run_command(
+                        ["transaction", "submit", "--tx-file", tmp_tx_file.name]
+                        + self._network_args
+                    )
+                except CardanoCliError as err:
+                    raise TransactionFailedException(
+                        "Failed to submit transaction"
+                    ) from err
 
             # Get the transaction ID
             try:
                 txid = self._run_command(
-                    ["transaction", "txid", "--tx-file", tmp_tx_file.name]
+                    ["latest", "transaction", "txid", "--tx-file", tmp_tx_file.name]
                 )
-            except CardanoCliError as err:
-                raise PyCardanoException(
-                    f"Unable to get transaction id for {tmp_tx_file.name}"
-                ) from err
+            except CardanoCliError:
+                try:
+                    txid = self._run_command(
+                        ["transaction", "txid", "--tx-file", tmp_tx_file.name]
+                    )
+                except CardanoCliError as err:
+                    raise PyCardanoException(
+                        f"Unable to get transaction id for {tmp_tx_file.name}"
+                    ) from err
 
         return txid

--- a/pycardano/backend/cardano_cli.py
+++ b/pycardano/backend/cardano_cli.py
@@ -44,6 +44,11 @@ from pycardano.transaction import (
     Value,
 )
 from pycardano.types import JsonDict
+from pycardano.utils import greater_than_version
+
+if greater_than_version((3, 13)):
+    from enum import member  # type: ignore[attr-defined]
+
 
 __all__ = ["CardanoCliChainContext", "CardanoCliNetwork", "DockerConfig"]
 
@@ -70,7 +75,11 @@ class CardanoCliNetwork(Enum):
     PREVIEW = ["--testnet-magic", str(2)]
     PREPROD = ["--testnet-magic", str(1)]
     GUILDNET = ["--testnet-magic", str(141)]
-    CUSTOM = partial(network_magic)
+    CUSTOM = (
+        member(partial(network_magic))
+        if greater_than_version((3, 13))
+        else partial(network_magic)
+    )
 
 
 class DockerConfig:

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -579,7 +579,7 @@ class TransactionBody(MapCBORSerializable):
 
     certificates: Optional[
         Union[List[Certificate], NonEmptyOrderedSet[Certificate]]
-    ]  = field(
+    ] = field(
         default=None,
         metadata={
             "key": 4,

--- a/pycardano/transaction.py
+++ b/pycardano/transaction.py
@@ -577,7 +577,9 @@ class TransactionBody(MapCBORSerializable):
 
     ttl: Optional[int] = field(default=None, metadata={"key": 3, "optional": True})
 
-    certificates: Optional[List[Certificate]] = field(
+    certificates: Optional[
+        Union[List[Certificate], NonEmptyOrderedSet[Certificate]]
+    ]  = field(
         default=None,
         metadata={
             "key": 4,

--- a/pycardano/utils.py
+++ b/pycardano/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import sys
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import cbor2
 from nacl.encoding import RawEncoder

--- a/pycardano/utils.py
+++ b/pycardano/utils.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import math
-from typing import Dict, List, Optional, Union
+import sys
+from typing import Dict, List, Optional, Union, Tuple
 
 import cbor2
 from nacl.encoding import RawEncoder
@@ -24,6 +25,7 @@ __all__ = [
     "min_lovelace_post_alonzo",
     "script_data_hash",
     "tiered_reference_script_fee",
+    "greater_than_version",
 ]
 
 
@@ -266,3 +268,15 @@ def script_data_hash(
             encoder=RawEncoder,
         )
     )
+
+
+def greater_than_version(version: Tuple[int, int]) -> bool:
+    """Check if the current Python version is greater than or equal to the specified version
+
+    Args:
+        version (Tuple[int, int]): Tuple of major and minor version
+
+    Returns:
+        True if the current Python version is greater than or equal to the specified version
+    """
+    return sys.version_info >= version

--- a/test/pycardano/backend/test_cardano_cli.py
+++ b/test/pycardano/backend/test_cardano_cli.py
@@ -8,15 +8,17 @@ import pytest
 from pycardano import (
     ALONZO_COINS_PER_UTXO_WORD,
     CardanoCliChainContext,
+    CardanoCliError,
     CardanoCliNetwork,
     DatumHash,
     GenesisParameters,
     MultiAsset,
     PlutusV2Script,
     ProtocolParameters,
+    PyCardanoException,
     RawPlutusData,
+    TransactionFailedException,
     TransactionInput,
-    CardanoCliError,
 )
 
 QUERY_TIP_RESULT = {
@@ -484,50 +486,6 @@ QUERY_UTXO_RESULT = {
 }
 
 
-def override_run_command_older_version(cmd: List[str]):
-    """
-    Override the run_command method of CardanoCliChainContext to return a mock result of older versions of cardano-cli.
-    Args:
-        cmd: The command to run
-
-    Returns:
-        The mock result
-    """
-    if "latest" in cmd:
-        raise CardanoCliError(
-            "Older versions of cardano-cli do not support the latest command"
-        )
-    if "tip" in cmd:
-        return json.dumps(QUERY_TIP_RESULT)
-    if "protocol-parameters" in cmd:
-        return json.dumps(QUERY_PROTOCOL_PARAMETERS_RESULT)
-    if "utxo" in cmd:
-        return json.dumps(QUERY_UTXO_RESULT)
-    if "txid" in cmd:
-        return "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
-    if "version" in cmd:
-        return "cardano-cli 8.1.2 - linux-x86_64 - ghc-8.10\ngit rev d2d90b48c5577b4412d5c9c9968b55f8ab4b9767"
-    else:
-        return None
-
-
-def override_run_command_latest(cmd: List[str]):
-    """
-    Override the run_command method of CardanoCliChainContext to return a mock result of the latest versions of cardano-cli.
-    Args:
-        cmd: The command to run
-
-    Returns:
-        The mock result
-    """
-    if "tip" in cmd:
-        return json.dumps(QUERY_TIP_RESULT)
-    if "txid" in cmd:
-        return "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
-    else:
-        return None
-
-
 @pytest.fixture
 def chain_context(genesis_file, config_file):
     """
@@ -539,6 +497,33 @@ def chain_context(genesis_file, config_file):
     Returns:
         The CardanoCliChainContext
     """
+
+    def override_run_command_older_version(cmd: List[str]):
+        """
+        Override the run_command method of CardanoCliChainContext to return a mock result of older versions of cardano-cli.
+        Args:
+            cmd: The command to run
+
+        Returns:
+            The mock result
+        """
+        if "latest" in cmd:
+            raise CardanoCliError(
+                "Older versions of cardano-cli do not support the latest command"
+            )
+        if "tip" in cmd:
+            return json.dumps(QUERY_TIP_RESULT)
+        if "protocol-parameters" in cmd:
+            return json.dumps(QUERY_PROTOCOL_PARAMETERS_RESULT)
+        if "utxo" in cmd:
+            return json.dumps(QUERY_UTXO_RESULT)
+        if "txid" in cmd:
+            return "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
+        if "version" in cmd:
+            return "cardano-cli 8.1.2 - linux-x86_64 - ghc-8.10\ngit rev d2d90b48c5577b4412d5c9c9968b55f8ab4b9767"
+        else:
+            return None
+
     with patch(
         "pycardano.backend.cardano_cli.CardanoCliChainContext._run_command",
         side_effect=override_run_command_older_version,
@@ -564,6 +549,23 @@ def chain_context_latest(genesis_file, config_file):
     Returns:
         The CardanoCliChainContext
     """
+
+    def override_run_command_latest(cmd: List[str]):
+        """
+        Override the run_command method of CardanoCliChainContext to return a mock result of the latest versions of cardano-cli.
+        Args:
+            cmd: The command to run
+
+        Returns:
+            The mock result
+        """
+        if "tip" in cmd:
+            return json.dumps(QUERY_TIP_RESULT)
+        if "txid" in cmd:
+            return "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
+        else:
+            return None
+
     with patch(
         "pycardano.backend.cardano_cli.CardanoCliChainContext._run_command",
         side_effect=override_run_command_latest,
@@ -575,6 +577,72 @@ def chain_context_latest(genesis_file, config_file):
             network=CardanoCliNetwork.PREPROD,
         )
         context._run_command = override_run_command_latest
+    return context
+
+
+@pytest.fixture
+def chain_context_tx_fail(genesis_file, config_file):
+    """
+    Create a CardanoCliChainContext with a mock run_command method
+    Args:
+        genesis_file: The genesis file
+        config_file: The config file
+
+    Returns:
+        The CardanoCliChainContext
+    """
+
+    def override_run_command_fail(cmd: List[str]):
+        if "transaction" in cmd:
+            raise CardanoCliError("Intentionally raised error for testing purposes")
+        if "tip" in cmd:
+            return json.dumps(QUERY_TIP_RESULT)
+        return None
+
+    with patch(
+        "pycardano.backend.cardano_cli.CardanoCliChainContext._run_command",
+        side_effect=override_run_command_fail,
+    ):
+        context = CardanoCliChainContext(
+            binary=Path("cardano-cli"),
+            socket=Path("node.socket"),
+            config_file=config_file,
+            network=CardanoCliNetwork.PREPROD,
+        )
+        context._run_command = override_run_command_fail
+    return context
+
+
+@pytest.fixture
+def chain_context_tx_id_fail(genesis_file, config_file):
+    """
+    Create a CardanoCliChainContext with a mock run_command method
+    Args:
+        genesis_file: The genesis file
+        config_file: The config file
+
+    Returns:
+        The CardanoCliChainContext
+    """
+
+    def override_run_command_fail(cmd: List[str]):
+        if "txid" in cmd:
+            raise CardanoCliError("Intentionally raised error for testing purposes")
+        if "tip" in cmd:
+            return json.dumps(QUERY_TIP_RESULT)
+        return None
+
+    with patch(
+        "pycardano.backend.cardano_cli.CardanoCliChainContext._run_command",
+        side_effect=override_run_command_fail,
+    ):
+        context = CardanoCliChainContext(
+            binary=Path("cardano-cli"),
+            socket=Path("node.socket"),
+            config_file=config_file,
+            network=CardanoCliNetwork.PREPROD,
+        )
+        context._run_command = override_run_command_fail
     return context
 
 
@@ -792,6 +860,16 @@ class TestCardanoCliChainContext:
             results
             == "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
         )
+
+    def test_submit_tx_fail(self, chain_context_tx_fail):
+        with pytest.raises(TransactionFailedException) as exc_info:
+            chain_context_tx_fail.submit_tx("testcborhexfromtransaction")
+        assert str(exc_info.value) == "Failed to submit transaction"
+
+    def test_submit_tx_id_fail(self, chain_context_tx_id_fail):
+        with pytest.raises(PyCardanoException) as exc_info:
+            chain_context_tx_id_fail.submit_tx("testcborhexfromtransaction")
+        assert str(exc_info.value).startswith("Unable to get transaction id for")
 
     def test_epoch(self, chain_context):
         assert chain_context.epoch == 98

--- a/test/pycardano/backend/test_cardano_cli.py
+++ b/test/pycardano/backend/test_cardano_cli.py
@@ -16,6 +16,7 @@ from pycardano import (
     ProtocolParameters,
     RawPlutusData,
     TransactionInput,
+    CardanoCliError,
 )
 
 QUERY_TIP_RESULT = {
@@ -483,15 +484,19 @@ QUERY_UTXO_RESULT = {
 }
 
 
-def override_run_command(cmd: List[str]):
+def override_run_command_older_version(cmd: List[str]):
     """
-    Override the run_command method of CardanoCliChainContext to return a mock result
+    Override the run_command method of CardanoCliChainContext to return a mock result of older versions of cardano-cli.
     Args:
         cmd: The command to run
 
     Returns:
         The mock result
     """
+    if "latest" in cmd:
+        raise CardanoCliError(
+            "Older versions of cardano-cli do not support the latest command"
+        )
     if "tip" in cmd:
         return json.dumps(QUERY_TIP_RESULT)
     if "protocol-parameters" in cmd:
@@ -502,6 +507,23 @@ def override_run_command(cmd: List[str]):
         return "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
     if "version" in cmd:
         return "cardano-cli 8.1.2 - linux-x86_64 - ghc-8.10\ngit rev d2d90b48c5577b4412d5c9c9968b55f8ab4b9767"
+    else:
+        return None
+
+
+def override_run_command_latest(cmd: List[str]):
+    """
+    Override the run_command method of CardanoCliChainContext to return a mock result of the latest versions of cardano-cli.
+    Args:
+        cmd: The command to run
+
+    Returns:
+        The mock result
+    """
+    if "tip" in cmd:
+        return json.dumps(QUERY_TIP_RESULT)
+    if "txid" in cmd:
+        return "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
     else:
         return None
 
@@ -519,7 +541,7 @@ def chain_context(genesis_file, config_file):
     """
     with patch(
         "pycardano.backend.cardano_cli.CardanoCliChainContext._run_command",
-        side_effect=override_run_command,
+        side_effect=override_run_command_older_version,
     ):
         context = CardanoCliChainContext(
             binary=Path("cardano-cli"),
@@ -527,7 +549,32 @@ def chain_context(genesis_file, config_file):
             config_file=config_file,
             network=CardanoCliNetwork.PREPROD,
         )
-        context._run_command = override_run_command
+        context._run_command = override_run_command_older_version
+    return context
+
+
+@pytest.fixture
+def chain_context_latest(genesis_file, config_file):
+    """
+    Create a CardanoCliChainContext with a mock run_command method
+    Args:
+        genesis_file: The genesis file
+        config_file: The config file
+
+    Returns:
+        The CardanoCliChainContext
+    """
+    with patch(
+        "pycardano.backend.cardano_cli.CardanoCliChainContext._run_command",
+        side_effect=override_run_command_latest,
+    ):
+        context = CardanoCliChainContext(
+            binary=Path("cardano-cli"),
+            socket=Path("node.socket"),
+            config_file=config_file,
+            network=CardanoCliNetwork.PREPROD,
+        )
+        context._run_command = override_run_command_latest
     return context
 
 
@@ -722,8 +769,24 @@ class TestCardanoCliChainContext:
             "55fe36f482e21ff6ae2caf2e33c3565572b568852dccd3f317ddecb91463d780"
         )
 
+    def test_submit_tx_bytes(self, chain_context):
+        results = chain_context.submit_tx("testcborhexfromtransaction".encode("utf-8"))
+
+        assert (
+            results
+            == "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
+        )
+
     def test_submit_tx(self, chain_context):
         results = chain_context.submit_tx("testcborhexfromtransaction")
+
+        assert (
+            results
+            == "270be16fa17cdb3ef683bf2c28259c978d4b7088792074f177c8efda247e23f7"
+        )
+
+    def test_submit_tx_latest(self, chain_context_latest):
+        results = chain_context_latest.submit_tx("testcborhexfromtransaction")
 
         assert (
             results


### PR DESCRIPTION

This pull request introduces 3 small but crucial fixes. 

### Certificates type in TransactionBody:
* Modified the `certificates` field in the `TransactionBody` class to accept either a `List` or a `NonEmptyOrderedSet` of `Certificate` objects, providing compatibility with the various ways transactions can be generated.

### Cardano-cli Transaction submission:
* Enhanced the `cardano-cli` transaction submit method command by attempting to use the `latest` prefix for compatability with the latest versions with fallback to the original command.

### Python version compatibility:
* Added a new utility function `greater_than_version` in `pycardano/utils.py` to check if the current Python version is greater than or equal to a specified version. This is used to conditionally import and utilize the `member` attribute from the `enum` module in Python 3.13+ to handle FutureWarning.