### PR TITLE
Add support for NonEmptyOrderedSet in Plutus_data

### DIFF
--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -24,7 +24,6 @@ from typing import (
     List,
     Optional,
     Sequence,
-    Set,
     Type,
     TypeVar,
     Union,
@@ -160,6 +159,7 @@ PRIMITIVE_TYPES = (
     Fraction,
     FrozenList,
     IndefiniteFrozenList,
+    ByteString,
 )
 """
 A list of types that could be encoded by
@@ -1128,14 +1128,15 @@ def list_hook(
     return lambda vals: [cls.from_primitive(v) for v in vals]
 
 
-class OrderedSet(list, IndefiniteList, Generic[T], CBORSerializable):  # type: ignore
+class OrderedSet(Generic[T], CBORSerializable):  # type: ignore
     def __init__(
         self,
         iterable: Optional[Union[List[T], IndefiniteList]] = None,
         use_tag: bool = True,
     ):
         super().__init__()
-        self._set: Set[str] = set()
+        self._dict: Dict[bytes, int] = {}
+        self._list: List[T] = []
         self._use_tag = use_tag
         self._is_indefinite_list = False
         if iterable:
@@ -1143,18 +1144,37 @@ class OrderedSet(list, IndefiniteList, Generic[T], CBORSerializable):  # type: i
             self.extend(iterable)
 
     def append(self, item: T) -> None:
-        item_key = str(item)
-        if item_key not in self._set:
-            super().append(item)
-            self._set.add(item_key)
+        if item in self:
+            return
+        self._list.append(item)
+        self._dict[dumps(item, default=default_encoder)] = len(self._list) - 1
 
     def extend(self, items: Iterable[T]) -> None:
         self._is_indefinite_list = isinstance(items, IndefiniteList)
         for item in items:
             self.append(item)
 
+    def remove(self, item: T) -> None:
+        if item not in self:
+            return
+        index = self._dict.pop(dumps(item, default=default_encoder))
+        self._list.pop(index)
+        # Update the indices in the dictionary
+        for key, idx in self._dict.items():
+            if idx > index:
+                self._dict[key] = idx - 1
+
     def __contains__(self, item: object) -> bool:
-        return str(item) in self._set
+        return dumps(item, default=default_encoder) in self._dict
+
+    def __iter__(self):
+        return iter(self._list)
+
+    def __getitem__(self, index: int) -> T:
+        return self._list[index]
+
+    def __len__(self) -> int:
+        return len(self._list)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, OrderedSet):

--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -1128,7 +1128,7 @@ def list_hook(
     return lambda vals: [cls.from_primitive(v) for v in vals]
 
 
-class OrderedSet(Generic[T], CBORSerializable):  # type: ignore
+class OrderedSet(Generic[T], CBORSerializable):
     def __init__(
         self,
         iterable: Optional[Union[List[T], IndefiniteList]] = None,

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -616,7 +616,9 @@ class TransactionBuilder:
                         )
                     )
             return script_data_hash(
-                self.redeemers(), list(self.datums.values()), CostModels(cost_models)
+                self.redeemers(),
+                NonEmptyOrderedSet(list(self.datums.values())),
+                CostModels(cost_models),
             )
         else:
             return None

--- a/pycardano/txbuilder.py
+++ b/pycardano/txbuilder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field, fields
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from pycardano import RedeemerMap
 from pycardano.address import Address, AddressType
@@ -1170,6 +1170,7 @@ class TransactionBuilder:
         plutus_v1_scripts: NonEmptyOrderedSet[PlutusV1Script] = NonEmptyOrderedSet()
         plutus_v2_scripts: NonEmptyOrderedSet[PlutusV2Script] = NonEmptyOrderedSet()
         plutus_v3_scripts: NonEmptyOrderedSet[PlutusV3Script] = NonEmptyOrderedSet()
+        plutus_data: NonEmptyOrderedSet[Any] = NonEmptyOrderedSet()
 
         input_scripts = (
             {
@@ -1180,6 +1181,9 @@ class TransactionBuilder:
             if remove_dup_script
             else {}
         )
+
+        for datum in self.datums.values():
+            plutus_data.append(datum)
 
         for script in self.scripts:
             if script_hash(script) not in input_scripts:
@@ -1204,7 +1208,7 @@ class TransactionBuilder:
             plutus_v2_script=plutus_v2_scripts if plutus_v2_scripts else None,
             plutus_v3_script=plutus_v3_scripts if plutus_v3_scripts else None,
             redeemer=self.redeemers() if self._redeemer_list else None,
-            plutus_data=list(self.datums.values()) if self.datums else None,
+            plutus_data=plutus_data if plutus_data else None,
         )
 
     def _ensure_no_input_exclusion_conflict(self):

--- a/pycardano/utils.py
+++ b/pycardano/utils.py
@@ -12,7 +12,7 @@ from nacl.hash import blake2b
 
 from pycardano.backend.base import ChainContext
 from pycardano.hash import SCRIPT_DATA_HASH_SIZE, SCRIPT_HASH_SIZE, ScriptDataHash
-from pycardano.plutus import COST_MODELS, CostModels, Datum, Redeemers
+from pycardano.plutus import COST_MODELS, CostModels, Datum, Redeemers, RedeemerMap
 from pycardano.serialization import NonEmptyOrderedSet, default_encoder
 from pycardano.transaction import MultiAsset, TransactionOutput, Value
 
@@ -249,14 +249,14 @@ def script_data_hash(
     Returns:
         ScriptDataHash: Plutus script data hash
     """
-    # Handle empty redeemers case - should be encoded as an empty map (A0 in hex)
+    # Handle empty redeemers case - should be encoded as an empty RedeemerMap (A0 in hex)
     if not redeemers:
-        redeemer_bytes = cbor2.dumps({}, default=default_encoder)
+        redeemers = RedeemerMap()
         cost_models = {}
-    else:
-        redeemer_bytes = cbor2.dumps(redeemers, default=default_encoder)
-        if not cost_models:
-            cost_models = COST_MODELS
+    elif not cost_models:
+        cost_models = COST_MODELS
+
+    redeemer_bytes = cbor2.dumps(redeemers, default=default_encoder)
 
     # Handle datums - if no datums, use empty bytestring
     if datums:

--- a/pycardano/utils.py
+++ b/pycardano/utils.py
@@ -260,13 +260,7 @@ def script_data_hash(
     redeemer_bytes = cbor2.dumps(redeemers, default=default_encoder)
 
     if datums:
-        if not isinstance(datums, NonEmptyOrderedSet):
-            # If datums is not a NonEmptyOrderedSet, handle it as a list
-            datum_bytes = cbor2.dumps(datums, default=default_encoder)
-        else:
-            datum_bytes = cbor2.dumps(
-                datums.to_shallow_primitive(), default=default_encoder
-            )
+        datum_bytes = cbor2.dumps(datums, default=default_encoder)
     else:
         datum_bytes = b""
 

--- a/pycardano/utils.py
+++ b/pycardano/utils.py
@@ -12,7 +12,7 @@ from nacl.hash import blake2b
 
 from pycardano.backend.base import ChainContext
 from pycardano.hash import SCRIPT_DATA_HASH_SIZE, SCRIPT_HASH_SIZE, ScriptDataHash
-from pycardano.plutus import COST_MODELS, CostModels, Datum, Redeemers, RedeemerMap
+from pycardano.plutus import COST_MODELS, CostModels, Datum, RedeemerMap, Redeemers
 from pycardano.serialization import NonEmptyOrderedSet, default_encoder
 from pycardano.transaction import MultiAsset, TransactionOutput, Value
 
@@ -260,13 +260,13 @@ def script_data_hash(
 
     # Handle datums - if no datums, use empty bytestring
     if datums:
-        if isinstance(datums, list):
-            # If datums is a NonEmptyOrderedSet, convert it to a shallow primitive representation
-            # to ensure correct CBOR encoding
-            datums = NonEmptyOrderedSet(datums)
-        datum_bytes = cbor2.dumps(
-            datums.to_shallow_primitive(), default=default_encoder
-        )
+        if not isinstance(datums, NonEmptyOrderedSet):
+            # If datums is not a NonEmptyOrderedSet, handle it as a list
+            datum_bytes = cbor2.dumps(datums, default=default_encoder)
+        else:
+            datum_bytes = cbor2.dumps(
+                datums.to_shallow_primitive(), default=default_encoder
+            )
     else:
         datum_bytes = b""
 

--- a/pycardano/witness.py
+++ b/pycardano/witness.py
@@ -12,6 +12,7 @@ from pycardano.nativescript import NativeScript
 from pycardano.plutus import PlutusV1Script, PlutusV2Script, PlutusV3Script, Redeemers
 from pycardano.serialization import (
     ArrayCBORSerializable,
+    IndefiniteList,
     MapCBORSerializable,
     NonEmptyOrderedSet,
     limit_primitive_type,
@@ -107,9 +108,11 @@ class TransactionWitnessSet(MapCBORSerializable):
         },
     )
 
-    plutus_data: Optional[Union[List[Any], NonEmptyOrderedSet[Any]]] = field(
-        default=None,
-        metadata={"optional": True, "key": 4},
+    plutus_data: Optional[Union[IndefiniteList, List[Any], NonEmptyOrderedSet[Any]]] = (
+        field(
+            default=None,
+            metadata={"optional": True, "key": 4},
+        )
     )
 
     redeemer: Optional[Redeemers] = field(

--- a/pycardano/witness.py
+++ b/pycardano/witness.py
@@ -9,19 +9,12 @@ from pprintpp import pformat
 
 from pycardano.key import ExtendedVerificationKey, VerificationKey
 from pycardano.nativescript import NativeScript
-from pycardano.plutus import (
-    PlutusV1Script,
-    PlutusV2Script,
-    PlutusV3Script,
-    RawPlutusData,
-    Redeemers,
-)
+from pycardano.plutus import PlutusV1Script, PlutusV2Script, PlutusV3Script, Redeemers
 from pycardano.serialization import (
     ArrayCBORSerializable,
     MapCBORSerializable,
     NonEmptyOrderedSet,
     limit_primitive_type,
-    list_hook,
 )
 
 __all__ = ["VerificationKeyWitness", "TransactionWitnessSet"]
@@ -114,9 +107,9 @@ class TransactionWitnessSet(MapCBORSerializable):
         },
     )
 
-    plutus_data: Optional[List[Any]] = field(
+    plutus_data: Optional[Union[List[Any], NonEmptyOrderedSet[Any]]] = field(
         default=None,
-        metadata={"optional": True, "key": 4, "object_hook": list_hook(RawPlutusData)},
+        metadata={"optional": True, "key": 4},
     )
 
     redeemer: Optional[Redeemers] = field(
@@ -150,6 +143,10 @@ class TransactionWitnessSet(MapCBORSerializable):
             self.vkey_witnesses = NonEmptyOrderedSet(self.vkey_witnesses)
         if isinstance(self.native_scripts, list):
             self.native_scripts = NonEmptyOrderedSet(self.native_scripts)
+        if isinstance(self.plutus_data, list) and not isinstance(
+            self.plutus_data, NonEmptyOrderedSet
+        ):
+            self.plutus_data = NonEmptyOrderedSet(list(self.plutus_data))
         if isinstance(self.plutus_v1_script, list):
             self.plutus_v1_script = NonEmptyOrderedSet(self.plutus_v1_script)
         if isinstance(self.plutus_v2_script, list):

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -638,6 +638,23 @@ def test_ordered_set():
     assert list(s) == [1, 2, 3]
     assert s._use_tag
 
+    # Test remove
+    s = OrderedSet([1, 2, 3, 4])
+    s.remove(2)
+    assert list(s) == [1, 3, 4]
+    assert 2 not in s
+    assert 1 in s
+    assert 3 in s
+    assert 4 in s
+    s.remove(2)
+    assert list(s) == [1, 3, 4]
+    assert 2 not in s
+    s.remove(3)
+    assert list(s) == [1, 4]
+    assert 3 not in s
+    s.remove(4)
+    assert list(s) == [1]
+
 
 def test_ordered_set_with_complex_types():
     # Test with VerificationKeyWitness
@@ -909,9 +926,9 @@ def test_ordered_set_deepcopy():
     assert 4 not in s
 
     # Test with complex objects
-    class TestObj:
-        def __init__(self, value):
-            self.value = value
+    @dataclass(repr=False)
+    class TestObj(ArrayCBORSerializable):
+        value: str
 
         def __str__(self):
             return f"TestObj({self.value})"

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -411,12 +411,12 @@ def test_tx_builder_mint_multi_asset(chain_context):
             [
                 sender_address.to_primitive(),
                 [
-                    5809111,
+                    5809155,
                     {b"1111111111111111111111111111": {b"Token1": 1, b"Token2": 2}},
                 ],
             ],
         ],
-        2: 190889,
+        2: 190845,
         3: 123456789,
         8: 1000,
         9: mint,

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -411,12 +411,12 @@ def test_tx_builder_mint_multi_asset(chain_context):
             [
                 sender_address.to_primitive(),
                 [
-                    5809155,
+                    5809111,
                     {b"1111111111111111111111111111": {b"Token1": 1, b"Token2": 2}},
                 ],
             ],
         ],
-        2: 190845,
+        2: 190889,
         3: 123456789,
         8: 1000,
         9: mint,

--- a/test/pycardano/test_util.py
+++ b/test/pycardano/test_util.py
@@ -3,7 +3,17 @@ from test.pycardano.util import chain_context
 import pytest
 
 from pycardano.hash import SCRIPT_HASH_SIZE, ScriptDataHash
-from pycardano.plutus import ExecutionUnits, PlutusData, Redeemer, RedeemerTag, Unit
+from pycardano.plutus import (
+    COST_MODELS,
+    ExecutionUnits,
+    PlutusData,
+    Redeemer,
+    RedeemerKey,
+    RedeemerMap,
+    RedeemerTag,
+    RedeemerValue,
+    Unit,
+)
 from pycardano.transaction import Value
 from pycardano.utils import (
     min_lovelace_pre_alonzo,
@@ -156,14 +166,31 @@ def test_script_data_hash():
     redeemers = [Redeemer(unit, ExecutionUnits(1000000, 1000000))]
     redeemers[0].tag = RedeemerTag.SPEND
     assert ScriptDataHash.from_primitive(
-        "032d812ee0731af78fe4ec67e4d30d16313c09e6fb675af28f825797e8b5621d"
+        "2ad155a692b0ddb6752df485de0a6bdb947757f9f998ff34a6f4b06ca0664fbe"
     ) == script_data_hash(redeemers=redeemers, datums=[unit])
+
+
+def test_script_data_hash_redeemer_map():
+    unit = Unit()
+    redeemer = Redeemer(42, ExecutionUnits(573240, 253056459))
+    redeemer.tag = RedeemerTag.SPEND
+    redeemers = RedeemerMap(
+        {
+            RedeemerKey(redeemer.tag, redeemer.index): RedeemerValue(
+                redeemer.data, redeemer.ex_units
+            )
+        }
+    )
+    cost_models = COST_MODELS
+    assert ScriptDataHash.from_primitive(
+        "04ad5eb241d1ede2bbbd60c5853de7659d2ecfb1a29d6cbb6921ef7bdd46ca3c"
+    ) == script_data_hash(redeemers=redeemers, datums=[unit], cost_models=cost_models)
 
 
 def test_script_data_hash_datum_only():
     unit = Unit()
     assert ScriptDataHash.from_primitive(
-        "2f50ea2546f8ce020ca45bfcf2abeb02ff18af2283466f888ae489184b3d2d39"
+        "264ea21d9904cd72ce5038fa60e0ddd0859383f7fbf60ecec6df22e4c4e34a1f"
     ) == script_data_hash(redeemers=[], datums=[unit])
 
 
@@ -171,7 +198,7 @@ def test_script_data_hash_redeemer_only():
     unit = Unit()
     redeemers = []
     assert ScriptDataHash.from_primitive(
-        "a88fe2947b8d45d1f8b798e52174202579ecf847b8f17038c7398103df2d27b0"
+        "9eb0251b2e85b082c3706a3e79b4cf2a2e96f936e912a398591e2486c757f8c1"
     ) == script_data_hash(redeemers=redeemers, datums=[])
 
 

--- a/test/pycardano/test_util.py
+++ b/test/pycardano/test_util.py
@@ -2,6 +2,7 @@ from test.pycardano.util import chain_context
 
 import pytest
 
+from pycardano import NonEmptyOrderedSet
 from pycardano.hash import SCRIPT_HASH_SIZE, ScriptDataHash
 from pycardano.plutus import (
     COST_MODELS,
@@ -166,7 +167,7 @@ def test_script_data_hash():
     redeemers = [Redeemer(unit, ExecutionUnits(1000000, 1000000))]
     redeemers[0].tag = RedeemerTag.SPEND
     assert ScriptDataHash.from_primitive(
-        "2ad155a692b0ddb6752df485de0a6bdb947757f9f998ff34a6f4b06ca0664fbe"
+        "032d812ee0731af78fe4ec67e4d30d16313c09e6fb675af28f825797e8b5621d"
     ) == script_data_hash(redeemers=redeemers, datums=[unit])
 
 
@@ -184,13 +185,15 @@ def test_script_data_hash_redeemer_map():
     cost_models = COST_MODELS
     assert ScriptDataHash.from_primitive(
         "04ad5eb241d1ede2bbbd60c5853de7659d2ecfb1a29d6cbb6921ef7bdd46ca3c"
-    ) == script_data_hash(redeemers=redeemers, datums=[unit], cost_models=cost_models)
+    ) == script_data_hash(
+        redeemers=redeemers, datums=NonEmptyOrderedSet([unit]), cost_models=cost_models
+    )
 
 
 def test_script_data_hash_datum_only():
     unit = Unit()
     assert ScriptDataHash.from_primitive(
-        "264ea21d9904cd72ce5038fa60e0ddd0859383f7fbf60ecec6df22e4c4e34a1f"
+        "244926529564c04ffdea89005076a6b6aac5e4a2f38182cd48bfbc734b3be296"
     ) == script_data_hash(redeemers=[], datums=[unit])
 
 

--- a/test/pycardano/test_util.py
+++ b/test/pycardano/test_util.py
@@ -193,7 +193,7 @@ def test_script_data_hash_redeemer_map():
 def test_script_data_hash_datum_only():
     unit = Unit()
     assert ScriptDataHash.from_primitive(
-        "244926529564c04ffdea89005076a6b6aac5e4a2f38182cd48bfbc734b3be296"
+        "2f50ea2546f8ce020ca45bfcf2abeb02ff18af2283466f888ae489184b3d2d39"
     ) == script_data_hash(redeemers=[], datums=[unit])
 
 
@@ -201,7 +201,7 @@ def test_script_data_hash_redeemer_only():
     unit = Unit()
     redeemers = []
     assert ScriptDataHash.from_primitive(
-        "9eb0251b2e85b082c3706a3e79b4cf2a2e96f936e912a398591e2486c757f8c1"
+        "a88fe2947b8d45d1f8b798e52174202579ecf847b8f17038c7398103df2d27b0"
     ) == script_data_hash(redeemers=redeemers, datums=[])
 
 


### PR DESCRIPTION
This pull request improves handling of indefinite lists, update encoding of Plutus data, and expanded test coverage. Key changes include updates to the `OrderedSet` class to support indefinite lists, modifications to the transaction builder and utilities for more robust Plutus data handling, and update tests to validate these updates.

### Enhancements to `OrderedSet` and Serialization:
* Updated the `OrderedSet` class to inherit from `IndefiniteList` and added support for indefinite list detection and representation. This ensures compatibility with CBOR encoding for both definite and indefinite lists (`pycardano/serialization.py`). [[1]](diffhunk://#diff-c4ba70db478a9e6b82d1c340bc3f581282a58b734c4ce68556d01413b8e16a77L1131-R1142) [[2]](diffhunk://#diff-c4ba70db478a9e6b82d1c340bc3f581282a58b734c4ce68556d01413b8e16a77R1152) [[3]](diffhunk://#diff-c4ba70db478a9e6b82d1c340bc3f581282a58b734c4ce68556d01413b8e16a77L1162-R1175)
* Extended `NonEmptyOrderedSet` to accept `IndefiniteList` as input, improving its flexibility (`pycardano/serialization.py`).

### Improvements in Plutus Data Handling:
* Modified `TransactionWitnessSet` to support `NonEmptyOrderedSet` for `plutus_data` (`pycardano/witness.py`). [[1]](diffhunk://#diff-02b560c75ee9ac1e0ee0d3d0b50cfe0e2e13c84d36ea708f5276df36636392c5L117-R112) [[2]](diffhunk://#diff-02b560c75ee9ac1e0ee0d3d0b50cfe0e2e13c84d36ea708f5276df36636392c5R146-R149)
* Updated the `build_witness_set` method to use `NonEmptyOrderedSet` for Plutus data (`pycardano/txbuilder.py`). [[1]](diffhunk://#diff-5f63e63d39d6c07ad21be34383c46afd02929ac237d9af6def0bdaac5dfd663fR1173) [[2]](diffhunk://#diff-5f63e63d39d6c07ad21be34383c46afd02929ac237d9af6def0bdaac5dfd663fR1185-R1187) [[3]](diffhunk://#diff-5f63e63d39d6c07ad21be34383c46afd02929ac237d9af6def0bdaac5dfd663fL1207-R1211)

### Enhancements to Utilities:
* Refactored the `script_data_hash` function to handle `NonEmptyOrderedSet` for datums and ensure canonical CBOR encoding for cost models (`pycardano/utils.py`).

### Test Coverage Expansion:
* Added new test cases to validate `script_data_hash` behavior with `RedeemerMap` and updated expected hash values to reflect changes in encoding logic (`test/pycardano/test_util.py`).
* Adjusted existing tests to align with the updated handling of Plutus data and indefinite lists (`test/pycardano/test_txbuilder.py`).