### PR TITLE
Don't exit script when c extension detected

### DIFF
--- a/ensure_pure_cbor2.sh
+++ b/ensure_pure_cbor2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script to ensure cbor2 is installed with pure Python implementation
 
-set -e
+set -x
 
 # Check if poetry is available, otherwise use python directly
 if command -v poetry &> /dev/null; then
@@ -16,7 +16,6 @@ CBOR2_VERSION=$(cat .cbor2_version)
 echo "Found cbor2 version: $CBOR2_VERSION"
 
 echo "Checking cbor2 implementation..."
-set +e
 $PYTHON -c "
 import cbor2, inspect, sys
 decoder_path = inspect.getfile(cbor2.CBORDecoder)
@@ -25,12 +24,11 @@ print(f'Implementation path: {decoder_path}')
 print(f'Using C extension: {using_c_ext}')
 sys.exit(1 if using_c_ext else 0)
 "
-set -e
 
 if [ $? -ne 0 ]; then
     echo "Reinstalling cbor2 with pure Python implementation..."
-    $PYTHON -m pip uninstall -y cbor2
-    CBOR2_BUILD_C_EXTENSION=0 $PYTHON -m pip install --no-binary cbor2 "cbor2==$CBOR2_VERSION" --force-reinstall
+    $PYTHON -m pip uninstall -y cbor2 || uv pip uninstall -y cbor2
+    CBOR2_BUILD_C_EXTENSION=0 $PYTHON -m pip install --no-binary cbor2 "cbor2==$CBOR2_VERSION" --force-reinstall || CBOR2_BUILD_C_EXTENSION=0 uv pip install --no-binary cbor2 "cbor2==$CBOR2_VERSION" --force-reinstall
     echo "Successfully reinstalled cbor2 with pure Python implementation"
 else
     echo "Already using pure Python implementation of cbor2"

--- a/ensure_pure_cbor2.sh
+++ b/ensure_pure_cbor2.sh
@@ -27,7 +27,7 @@ sys.exit(1 if using_c_ext else 0)
 
 if [ $? -ne 0 ]; then
     echo "Reinstalling cbor2 with pure Python implementation..."
-    $PYTHON -m pip uninstall -y cbor2 || uv pip uninstall -y cbor2
+    $PYTHON -m pip uninstall -y cbor2 || uv pip uninstall cbor2
     CBOR2_BUILD_C_EXTENSION=0 $PYTHON -m pip install --no-binary cbor2 "cbor2==$CBOR2_VERSION" --force-reinstall || CBOR2_BUILD_C_EXTENSION=0 uv pip install --no-binary cbor2 "cbor2==$CBOR2_VERSION" --force-reinstall
     echo "Successfully reinstalled cbor2 with pure Python implementation"
 else

--- a/ensure_pure_cbor2.sh
+++ b/ensure_pure_cbor2.sh
@@ -16,6 +16,7 @@ CBOR2_VERSION=$(cat .cbor2_version)
 echo "Found cbor2 version: $CBOR2_VERSION"
 
 echo "Checking cbor2 implementation..."
+set +e
 $PYTHON -c "
 import cbor2, inspect, sys
 decoder_path = inspect.getfile(cbor2.CBORDecoder)
@@ -24,6 +25,7 @@ print(f'Implementation path: {decoder_path}')
 print(f'Using C extension: {using_c_ext}')
 sys.exit(1 if using_c_ext else 0)
 "
+set -e
 
 if [ $? -ne 0 ]; then
     echo "Reinstalling cbor2 with pure Python implementation..."


### PR DESCRIPTION
Currently the script simply exits when the C extension is detected due to the `set -e` setting.


Also adds support for `uv`