### PR TITLE
Freeze indefinite lists and definite lists when decoding

### DIFF
--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -21,10 +21,12 @@ from typing import (
 import cbor2
 import pytest
 from cbor2 import CBORTag
+from frozenlist import FrozenList
 
 from pycardano import (
     CBORBase,
     Datum,
+    IndefiniteFrozenList,
     MultiAsset,
     Primitive,
     RawPlutusData,
@@ -618,8 +620,8 @@ def test_ordered_set():
     # Test serialization without tag
     s = OrderedSet([1, 2, 3], use_tag=False)
     primitive = s.to_primitive()
-    assert isinstance(primitive, list)
-    assert primitive == [1, 2, 3]
+    assert isinstance(primitive, (list, FrozenList))
+    assert list(primitive) == [1, 2, 3]
 
     # Test serialization with tag
     s = OrderedSet([1, 2, 3], use_tag=True)
@@ -695,8 +697,10 @@ def test_non_empty_ordered_set():
     # Test serialization without tag
     s = NonEmptyOrderedSet([1, 2, 3], use_tag=False)
     primitive = s.to_primitive()
-    assert isinstance(primitive, list)
-    assert primitive == [1, 2, 3]
+    from frozenlist import FrozenList
+
+    assert isinstance(primitive, (list, FrozenList))
+    assert list(primitive) == [1, 2, 3]
 
     # Test serialization with tag
     s = NonEmptyOrderedSet([1, 2, 3], use_tag=True)
@@ -1050,3 +1054,16 @@ def test_save_load():
 
         with pytest.raises(IOError):
             test1.save(f.name)
+
+
+def test_ordered_set_as_key_in_dict():
+    a = NonEmptyOrderedSet([1, 2, 3])
+
+    class MyTest(DictCBORSerializable):
+        KEY_TYPE = NonEmptyOrderedSet
+        VALUE_TYPE = int
+
+    d = MyTest()
+    d[a] = 1
+
+    check_two_way_cbor(d)

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1075,3 +1075,31 @@ def test_indefinite_list_highjacking_does_not_break_cbor2():
     encoded = cbor2.dumps(a, default=default_encoder)
     decoded = cbor2.loads(encoded)
     assert isinstance(list(decoded.keys())[0], IndefiniteList)
+
+def test_definite_list_highjacking_does_not_break_cbor2():
+    ls = FrozenList(["hello"])
+    ls.freeze()
+    a = {ls: 1}
+    encoded = cbor2.dumps(a, default=default_encoder)
+    decoded = cbor2.loads(encoded)
+    assert isinstance(list(decoded.keys())[0], (list, tuple))
+
+def test_indefinite_list_highjacking_does_not_break_cbor2_datum():
+    ls = IndefiniteFrozenList(["hello"])
+    ls.freeze()
+    datum = CBORTag(251, ls)
+    a = {datum: 1}
+    encoded = cbor2.dumps(a, default=default_encoder)
+    decoded = cbor2.loads(encoded)
+    assert isinstance(list(decoded.keys())[0], CBORTag)
+    assert isinstance(list(decoded.keys())[0].value, IndefiniteList)
+
+def test_definite_list_highjacking_does_not_break_cbor2_datum():
+    ls = FrozenList(["hello"])
+    ls.freeze()
+    datum = CBORTag(251, ls)
+    a = {datum: 1}
+    encoded = cbor2.dumps(a, default=default_encoder)
+    decoded = cbor2.loads(encoded)
+    assert isinstance(list(decoded.keys())[0], CBORTag)
+    assert isinstance(list(decoded.keys())[0].value, (list, tuple))

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1072,4 +1072,6 @@ def test_indefinite_list_highjacking_does_not_break_cbor2():
     ls = IndefiniteFrozenList(["hello"])
     ls.freeze()
     a = {ls: 1}
-    cbor2.loads(cbor2.dumps(a, default=default_encoder))
+    encoded = cbor2.dumps(a, default=default_encoder)
+    decoded = cbor2.loads(encoded)
+    assert isinstance(list(decoded.keys())[0], IndefiniteList)

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1107,3 +1107,16 @@ def test_definite_list_highjacking_does_not_break_cbor2_datum():
     decoded = cbor2.loads(encoded)
     assert isinstance(list(decoded.keys())[0], CBORTag)
     assert isinstance(list(decoded.keys())[0].value, (list, tuple))
+
+
+def test_ordered_set_as_key_in_dict_indefinite_list():
+    a = NonEmptyOrderedSet(IndefiniteList([1, 2, 3]))
+
+    class MyTest(DictCBORSerializable):
+        KEY_TYPE = NonEmptyOrderedSet
+        VALUE_TYPE = int
+
+    d = MyTest()
+    d[a] = 1
+
+    check_two_way_cbor(d)

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1068,6 +1068,7 @@ def test_ordered_set_as_key_in_dict():
 
     check_two_way_cbor(d)
 
+
 def test_indefinite_list_highjacking_does_not_break_cbor2():
     ls = IndefiniteFrozenList(["hello"])
     ls.freeze()
@@ -1076,6 +1077,7 @@ def test_indefinite_list_highjacking_does_not_break_cbor2():
     decoded = cbor2.loads(encoded)
     assert isinstance(list(decoded.keys())[0], IndefiniteList)
 
+
 def test_definite_list_highjacking_does_not_break_cbor2():
     ls = FrozenList(["hello"])
     ls.freeze()
@@ -1083,6 +1085,7 @@ def test_definite_list_highjacking_does_not_break_cbor2():
     encoded = cbor2.dumps(a, default=default_encoder)
     decoded = cbor2.loads(encoded)
     assert isinstance(list(decoded.keys())[0], (list, tuple))
+
 
 def test_indefinite_list_highjacking_does_not_break_cbor2_datum():
     ls = IndefiniteFrozenList(["hello"])
@@ -1093,6 +1096,7 @@ def test_indefinite_list_highjacking_does_not_break_cbor2_datum():
     decoded = cbor2.loads(encoded)
     assert isinstance(list(decoded.keys())[0], CBORTag)
     assert isinstance(list(decoded.keys())[0].value, IndefiniteList)
+
 
 def test_definite_list_highjacking_does_not_break_cbor2_datum():
     ls = FrozenList(["hello"])

--- a/test/pycardano/test_serialization.py
+++ b/test/pycardano/test_serialization.py
@@ -1067,3 +1067,9 @@ def test_ordered_set_as_key_in_dict():
     d[a] = 1
 
     check_two_way_cbor(d)
+
+def test_indefinite_list_highjacking_does_not_break_cbor2():
+    ls = IndefiniteFrozenList(["hello"])
+    ls.freeze()
+    a = {ls: 1}
+    cbor2.loads(cbor2.dumps(a, default=default_encoder))

--- a/test/pycardano/test_txbuilder.py
+++ b/test/pycardano/test_txbuilder.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 from cbor2 import CBORTag
+from frozenlist import FrozenList
 
 from pycardano import (
     AssetName,
@@ -69,6 +70,13 @@ from pycardano.utils import fee
 from pycardano.witness import TransactionWitnessSet, VerificationKeyWitness
 
 
+def frozen_list(items):
+    """Helper function to create a frozen list from items."""
+    fl = FrozenList(items)
+    fl.freeze()
+    return fl
+
+
 def test_tx_builder(chain_context):
     tx_builder = TransactionBuilder(chain_context, [RandomImproveMultiAsset([0, 0])])
     sender = "addr_test1vrm9x2zsux7va6w892g38tvchnzahvcd9tykqf3ygnmwtaqyfg52x"
@@ -82,7 +90,7 @@ def test_tx_builder(chain_context):
     tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 0]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 0]])),
         1: [
             # First output
             [sender_address.to_primitive(), 500000],
@@ -126,7 +134,7 @@ def test_tx_builder_with_certain_input(chain_context):
     tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
-        0: CBORTag(258, [[b"2" * 32, 1]]),
+        0: CBORTag(258, frozen_list([[b"2" * 32, 1]])),
         1: [
             # First output
             [sender_address.to_primitive(), 500000],
@@ -296,7 +304,7 @@ def test_tx_builder_with_potential_inputs(chain_context):
     tx_body = tx_builder.build(change_address=sender_address)
 
     expect = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 3]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 3]])),
         1: [
             # First output
             [sender_address.to_primitive(), 2500000],
@@ -397,10 +405,12 @@ def test_tx_builder_mint_multi_asset(chain_context):
     expected = {
         0: CBORTag(
             258,
-            [
-                [b"11111111111111111111111111111111", 0],
-                [b"22222222222222222222222222222222", 1],
-            ],
+            frozen_list(
+                [
+                    [b"11111111111111111111111111111111", 0],
+                    [b"22222222222222222222222222222222", 1],
+                ]
+            ),
         ),
         1: [
             # First output
@@ -420,7 +430,7 @@ def test_tx_builder_mint_multi_asset(chain_context):
         3: 123456789,
         8: 1000,
         9: mint,
-        14: CBORTag(258, [sender_address.payment_part.to_primitive()]),
+        14: CBORTag(258, frozen_list([sender_address.payment_part.to_primitive()])),
     }
 
     assert expected == tx_body.to_primitive()
@@ -1310,7 +1320,7 @@ def test_excluded_input(chain_context):
     tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
-        0: CBORTag(258, [[b"22222222222222222222222222222222", 1]]),
+        0: CBORTag(258, frozen_list([[b"22222222222222222222222222222222", 1]])),
         1: [
             # First output
             [sender_address.to_primitive(), 500000],
@@ -1448,7 +1458,7 @@ def test_tx_builder_exact_fee_no_change(chain_context):
     tx = tx_builder.build_and_sign([SK])
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 3]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 3]])),
         1: [
             [sender_address.to_primitive(), 9835951],
         ],
@@ -1484,7 +1494,7 @@ def test_tx_builder_certificates(chain_context):
     tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 0]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 0]])),
         1: [
             # First output
             [sender_address.to_primitive(), 500000],
@@ -1603,7 +1613,7 @@ def test_tx_builder_stake_pool_registration(chain_context, pool_params):
     tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
-        0: CBORTag(258, [[b"22222222222222222222222222222222", 2]]),
+        0: CBORTag(258, frozen_list([[b"22222222222222222222222222222222", 2]])),
         1: [
             [
                 b"`\xf6S(P\xe1\xbc\xce\xe9\xc7*\x91\x13\xad\x98\xbc\xc5\xdb\xb3\r*\xc9`&$D\xf6\xe5\xf4",
@@ -1659,7 +1669,7 @@ def test_tx_builder_withdrawal(chain_context):
     tx_body = tx_builder.build(change_address=sender_address)
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 0]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 0]])),
         1: [
             # First output
             [sender_address.to_primitive(), 500000],
@@ -1694,7 +1704,7 @@ def test_tx_builder_no_output(chain_context):
     )
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 3]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 3]])),
         1: [
             [sender_address.to_primitive(), 9835951],
         ],
@@ -1724,7 +1734,7 @@ def test_tx_builder_merge_change_to_output(chain_context):
     )
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 3]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 3]])),
         1: [
             [sender_address.to_primitive(), 9835951],
         ],
@@ -1758,7 +1768,7 @@ def test_tx_builder_merge_change_to_output_2(chain_context):
     )
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 3]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 3]])),
         1: [
             [sender_address.to_primitive(), 10000],
             [receiver_address.to_primitive(), 10000],
@@ -1790,7 +1800,7 @@ def test_tx_builder_merge_change_to_zero_amount_output(chain_context):
     )
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 3]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 3]])),
         1: [
             [sender_address.to_primitive(), 9835951],
         ],
@@ -1820,7 +1830,7 @@ def test_tx_builder_merge_change_smaller_than_min_utxo(chain_context):
     )
 
     expected = {
-        0: CBORTag(258, [[b"11111111111111111111111111111111", 3]]),
+        0: CBORTag(258, frozen_list([[b"11111111111111111111111111111111", 3]])),
         1: [
             [sender_address.to_primitive(), 9835951],
         ],


### PR DESCRIPTION
When decoding complex Cardano objects, it may happen that internally, there is a map of e.g. PlutusData -> X or Array -> X. This is fine in CBOR, but can lead to issues when translating this into corresponding Python objects which require hashability. I think for this reason, _all_ CBOR lists/maps should be decoded into a frozen variant to avoid errors during translation.

This patch implements the minimal fix to pass a testcase in Mockfrost (test_vesting2.py) (concretely, decoding the script context from cbor may fail here because it contains the datums map which maps arbitrarily complex datums to arbitrary data). However, more instances of decoded dicts and lists are present in serialization and may need to be adapted. I didn't want to do that right away as I may be unaware of things that break when we enforce freezing any decoded datastructure.