### PR TITLE
Expand Bech32 usage

### DIFF
--- a/pycardano/certificate.py
+++ b/pycardano/certificate.py
@@ -4,8 +4,20 @@ from dataclasses import dataclass, field
 from enum import Enum, unique
 from typing import Optional, Tuple, Type, Union
 
-from pycardano.exception import DeserializeException
-from pycardano.hash import AnchorDataHash, PoolKeyHash, ScriptHash, VerificationKeyHash
+from pycardano.crypto.bech32 import bech32_decode, convertbits, encode
+from pycardano.exception import (
+    DecodingException,
+    DeserializeException,
+    SerializeException,
+)
+from pycardano.hash import (
+    CIP129_PAYLOAD_SIZE,
+    VERIFICATION_KEY_HASH_SIZE,
+    AnchorDataHash,
+    PoolKeyHash,
+    ScriptHash,
+    VerificationKeyHash,
+)
 from pycardano.serialization import (
     ArrayCBORSerializable,
     CodedSerializable,
@@ -36,6 +48,8 @@ __all__ = [
     "RegDRepCert",
     "UnregDRepCertificate",
     "UpdateDRepCertificate",
+    "GovernanceCredential",
+    "GovernanceKeyType",
 ]
 
 from pycardano.pool_params import PoolParams
@@ -92,15 +106,171 @@ class StakeCredential(ArrayCBORSerializable):
         return hash(self.to_cbor())
 
 
+class IdFormat(Enum):
+    """
+    Id format definition.
+    """
+
+    CIP129 = "cip129"
+    CIP105 = "cip105"
+
+
+class CredentialType(Enum):
+    """
+    Credential type definition.
+    """
+
+    KEY_HASH = 0b0010
+    """Key hash"""
+
+    SCRIPT_HASH = 0b0011
+    """Script hash"""
+
+
+class GovernanceKeyType(Enum):
+    """
+    Governance key type definition.
+    """
+
+    CC_HOT = 0b0000
+    """Committee cold hot key"""
+
+    CC_COLD = 0b0001
+    """Committee cold key"""
+
+    DREP = 0b0010
+    """DRep key"""
+
+
 @dataclass(repr=False)
-class DRepCredential(StakeCredential):
+class GovernanceCredential(StakeCredential):
+    """Represents a governance credential."""
+
+    def __repr__(self):
+        return f"{self.encode()}"
+
+    def __bytes__(self):
+        return self._compute_header_byte() + bytes(self.credential.payload)
+
+    governance_key_type: GovernanceKeyType = field(init=False)
+    """Governance key type."""
+
+    def id(self, id_format: IdFormat = IdFormat.CIP129) -> str:
+        """
+        Governance credential ID.
+        """
+        return self.encode(id_format)
+
+    def id_hex(self, id_format: IdFormat = IdFormat.CIP129) -> str:
+        """
+        Governance credential ID in hexadecimal format.
+        """
+        if id_format == IdFormat.CIP129:
+            return bytes(self).hex()
+        else:
+            return bytes(self)[1:].hex()
+
+    @property
+    def credential_type(self) -> CredentialType:
+        """Credential type."""
+        if isinstance(self.credential, VerificationKeyHash):
+            return CredentialType.KEY_HASH
+        else:
+            return CredentialType.SCRIPT_HASH
+
+    def _compute_header_byte(self) -> bytes:
+        """Compute the header byte."""
+        return (
+            self.governance_key_type.value << 4 | self.credential_type.value
+        ).to_bytes(1, byteorder="big")
+
+    def _compute_hrp(self, id_format: IdFormat = IdFormat.CIP129) -> str:
+        """Compute human-readable prefix for bech32 encoder.
+
+        Based on
+        `miscellaneous section <https://github.com/cardano-foundation/CIPs/tree/master/CIP-0005#miscellaneous>`_
+        in CIP-5.
+        """
+        prefix = ""
+        if self.governance_key_type == GovernanceKeyType.CC_HOT:
+            prefix = "cc_hot"
+        elif self.governance_key_type == GovernanceKeyType.CC_COLD:
+            prefix = "cc_cold"
+        elif self.governance_key_type == GovernanceKeyType.DREP:
+            prefix = "drep"
+
+        suffix = ""
+        if isinstance(self.credential, VerificationKeyHash):
+            suffix = ""
+        elif isinstance(self.credential, ScriptHash):
+            suffix = "_script"
+
+        return prefix + suffix if id_format == IdFormat.CIP105 else prefix
+
+    def encode(self, id_format: IdFormat = IdFormat.CIP129) -> str:
+        """Encode the governance credential in Bech32 format.
+
+        More info about Bech32 `here <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#Bech32>`_.
+
+        Returns:
+            str: Encoded governance credential in Bech32 format.
+        """
+        data = bytes(self) if id_format == IdFormat.CIP129 else bytes(self)[1:]
+        return encode(self._compute_hrp(id_format), data)
+
+    @classmethod
+    def decode(cls: Type[GovernanceCredential], data: str) -> GovernanceCredential:
+        """Decode a bech32 string into a governance credential object.
+
+        Args:
+            data (str): Bech32-encoded string.
+
+        Returns:
+            GovernanceCredential: Decoded governance credential.
+
+        Raises:
+            DecodingException: When the input string is not a valid governance credential.
+        """
+        hrp, checksum, _ = bech32_decode(data)
+        value = bytes(convertbits(checksum, 5, 8, False))
+        if len(value) == VERIFICATION_KEY_HASH_SIZE:
+            # CIP-105
+            if "script" in hrp:
+                return cls(ScriptHash(value))
+            else:
+                return cls(VerificationKeyHash(value))
+        elif len(value) == CIP129_PAYLOAD_SIZE:
+            header = value[0]
+            payload = value[1:]
+
+            key_type = GovernanceKeyType((header & 0xF0) >> 4)
+            credential_type = CredentialType(header & 0x0F)
+
+            if key_type != cls.governance_key_type:
+                raise DecodingException(f"Invalid key type: {key_type}")
+
+            if credential_type == CredentialType.KEY_HASH:
+                return cls(VerificationKeyHash(payload))
+            elif credential_type == CredentialType.SCRIPT_HASH:
+                return cls(ScriptHash(payload))
+            else:
+                raise DecodingException(f"Invalid credential type: {credential_type}")
+        else:
+            raise DecodingException(f"Invalid data length: {len(data)}")
+
+    def to_primitive(self):
+        return [self._CODE, self.credential.to_primitive()]
+
+
+@dataclass(repr=False)
+class DRepCredential(GovernanceCredential):
     """Represents a Delegate Representative (DRep) credential.
 
     This credential type is specifically used for DReps in the governance system,
-    inheriting from StakeCredential.
+    inheriting from GovernanceCredential.
     """
 
-    pass
+    governance_key_type: GovernanceKeyType = GovernanceKeyType.DREP
 
 
 @unique
@@ -135,13 +305,28 @@ class DRep(ArrayCBORSerializable):
     )
     """The credential associated with this DRep, if applicable"""
 
+    def id(self, id_format: IdFormat = IdFormat.CIP129) -> str:
+        """
+        DRep ID.
+        """
+        return self.encode(id_format)
+
+    def id_hex(self, id_format: IdFormat = IdFormat.CIP129) -> str:
+        """
+        DRep ID in hexadecimal format.
+        """
+        if self.credential is not None:
+            drep_credential = DRepCredential(self.credential)
+            return drep_credential.id_hex(id_format)
+        return ""
+
     @classmethod
     @limit_primitive_type(list)
     def from_primitive(cls: Type[DRep], values: Union[list, tuple]) -> DRep:
         try:
             kind = DRepKind(values[0])
-        except ValueError:
-            raise DeserializeException(f"Invalid DRep type {values[0]}")
+        except ValueError as e:
+            raise DeserializeException(f"Invalid DRep type {values[0]}") from e
 
         if kind == DRepKind.VERIFICATION_KEY_HASH:
             return cls(kind=kind, credential=VerificationKeyHash(values[1]))
@@ -158,6 +343,63 @@ class DRep(ArrayCBORSerializable):
         if self.credential is not None:
             return [self.kind.value, self.credential.to_primitive()]
         return [self.kind.value]
+
+    def encode(self, id_format: IdFormat = IdFormat.CIP129) -> str:
+        """Encode the DRep in Bech32 format.
+
+        More info about Bech32 `here <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#Bech32>`_.
+
+        Returns:
+            str: Encoded DRep in Bech32 format.
+
+        Examples:
+            >>> vkey_bytes = bytes.fromhex("00000000000000000000000000000000000000000000000000000000")
+            >>> credential = VerificationKeyHash(vkey_bytes)
+            >>> print(DRep(kind=DRepKind.VERIFICATION_KEY_HASH, credential=credential).encode())
+            drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n
+        """
+        if self.kind == DRepKind.ALWAYS_ABSTAIN:
+            return "drep_always_abstain"
+        elif self.kind == DRepKind.ALWAYS_NO_CONFIDENCE:
+            return "drep_always_no_confidence"
+        elif self.credential is not None:
+            drep_credential = DRepCredential(self.credential)
+            return drep_credential.encode(id_format)
+        else:
+            raise SerializeException("DRep credential is None")
+
+    @classmethod
+    def decode(cls: Type[DRep], data: str) -> DRep:
+        """Decode a bech32 string into a DRep object.
+
+        Args:
+            data (str): Bech32-encoded string.
+
+        Returns:
+            DRep: Decoded DRep.
+
+        Raises:
+            DecodingException: When the input string is not a valid DRep.
+
+        Examples:
+            >>> credential = DRep.decode("drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n")
+            >>> khash = VerificationKeyHash(bytes.fromhex("00000000000000000000000000000000000000000000000000000000"))
+            >>> assert credential == DRep(DRepKind.VERIFICATION_KEY_HASH, khash)
+        """
+        if data == "drep_always_abstain":
+            return cls(kind=DRepKind.ALWAYS_ABSTAIN)
+        elif data == "drep_always_no_confidence":
+            return cls(kind=DRepKind.ALWAYS_NO_CONFIDENCE)
+        else:
+            drep_credential = DRepCredential.decode(data)
+            return cls(
+                kind=(
+                    DRepKind.VERIFICATION_KEY_HASH
+                    if isinstance(drep_credential.credential, VerificationKeyHash)
+                    else DRepKind.SCRIPT_HASH
+                ),
+                credential=drep_credential.credential,
+            )
 
 
 @dataclass(repr=False)

--- a/pycardano/hash.py
+++ b/pycardano/hash.py
@@ -15,6 +15,7 @@ __all__ = [
     "VRF_KEY_HASH_SIZE",
     "POOL_METADATA_HASH_SIZE",
     "REWARD_ACCOUNT_HASH_SIZE",
+    "CIP129_PAYLOAD_SIZE",
     "ConstrainedBytes",
     "VerificationKeyHash",
     "ScriptHash",
@@ -42,6 +43,7 @@ POOL_METADATA_HASH_SIZE = 32
 VRF_KEY_HASH_SIZE = 32
 REWARD_ACCOUNT_HASH_SIZE = 29
 ANCHOR_DATA_HASH_SIZE = 32
+CIP129_PAYLOAD_SIZE = 29
 
 
 T = TypeVar("T", bound="ConstrainedBytes")

--- a/pycardano/pool_params.py
+++ b/pycardano/pool_params.py
@@ -254,18 +254,6 @@ class PoolParams(ArrayCBORSerializable):
 class PoolOperator(CBORSerializable):
     pool_key_hash: PoolKeyHash
 
-    def id(self) -> PoolId:
-        """
-        Get the PoolId object for this pool operator.
-        """
-        return PoolId(self.encode())
-
-    def id_hex(self) -> str:
-        """
-        Get the pool key hash in hexadecimal format.
-        """
-        return self.pool_key_hash.payload.hex()
-
     def __init__(self, pool_key_hash: PoolKeyHash):
         self.pool_key_hash = pool_key_hash
 

--- a/pycardano/pool_params.py
+++ b/pycardano/pool_params.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass, field
 from fractions import Fraction
 from typing import List, Optional, Type, Union
 
-from pycardano.crypto.bech32 import bech32_decode
-from pycardano.exception import DeserializeException
+from pycardano.crypto.bech32 import bech32_decode, decode, encode
+from pycardano.exception import DecodingException, DeserializeException
 from pycardano.hash import (
     PoolKeyHash,
     PoolMetadataHash,
@@ -28,6 +28,7 @@ from pycardano.serialization import (
 __all__ = [
     "PoolId",
     "PoolMetadata",
+    "PoolOperator",
     "PoolParams",
     "Relay",
     "SingleHostAddr",
@@ -247,3 +248,85 @@ class PoolParams(ArrayCBORSerializable):
     relays: Optional[List[Relay]] = None
     pool_metadata: Optional[PoolMetadata] = None
     id: Optional[PoolId] = field(default=None, metadata={"optional": True})
+
+
+@dataclass(repr=False)
+class PoolOperator(CBORSerializable):
+    pool_key_hash: PoolKeyHash
+
+    def id(self) -> PoolId:
+        """
+        Get the PoolId object for this pool operator.
+        """
+        return PoolId(self.encode())
+
+    def id_hex(self) -> str:
+        """
+        Get the pool key hash in hexadecimal format.
+        """
+        return self.pool_key_hash.payload.hex()
+
+    def __init__(self, pool_key_hash: PoolKeyHash):
+        self.pool_key_hash = pool_key_hash
+
+    def __repr__(self):
+        return f"{self.encode()}"
+
+    def __bytes__(self):
+        return self.pool_key_hash.payload
+
+    def encode(self) -> str:
+        """Encode the pool key hash in Bech32 format.
+
+        More info about Bech32 `here <https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#Bech32>`_.
+
+        Returns:
+            str: Encoded pool key hash in Bech32.
+
+        Examples:
+            >>> pool_key_hash = PoolKeyHash(bytes.fromhex("cc30497f4ff962f4c1dca54cceefe39f86f1d7179668009f8eb71e59"))
+            >>> pool_operator = PoolOperator(pool_key_hash=pool_key_hash)
+            >>> print(pool_operator.encode())
+            pool1escyjl60l930fswu54xvamlrn7r0r4chje5qp8uwku09j7x68x6
+        """
+        return encode("pool", self.pool_key_hash.payload)
+
+    @classmethod
+    def decode(cls, data: str) -> PoolOperator:
+        """Decode a bech32 string into a pool operator object.
+
+        Args:
+            data (str): Bech32-encoded string.
+
+        Returns:
+            PoolOperator: Decoded pool operator.
+
+        Raises:
+            DecodingException: When the input string is not a valid Shelley address.
+
+        Examples:
+            >>> pool_operator = PoolOperator.decode("pool1escyjl60l930fswu54xvamlrn7r0r4chje5qp8uwku09j7x68x6")
+            >>> pool_key_hash = PoolKeyHash(bytes.fromhex("cc30497f4ff962f4c1dca54cceefe39f86f1d7179668009f8eb71e59"))
+            >>> assert pool_operator == PoolOperator(pool_key_hash)
+        """
+        return cls.from_primitive(data)
+
+    def to_shallow_primitive(self) -> bytes:
+        return self.pool_key_hash.to_primitive()
+
+    @classmethod
+    @limit_primitive_type(bytes, str)
+    def from_primitive(
+        cls: Type[PoolOperator], value: Union[bytes, str]
+    ) -> PoolOperator:
+        # Convert string to bytes
+        if isinstance(value, str):
+            # Check if bech32 poolid
+            if value.startswith("pool"):
+                value = bytes(decode(value))
+            else:
+                try:
+                    value = bytes.fromhex(value)
+                except Exception as e:
+                    raise DecodingException(f"Failed to decode pool id string: {e}") from e
+        return cls(PoolKeyHash.from_primitive(value))

--- a/pycardano/pool_params.py
+++ b/pycardano/pool_params.py
@@ -328,5 +328,7 @@ class PoolOperator(CBORSerializable):
                 try:
                     value = bytes.fromhex(value)
                 except Exception as e:
-                    raise DecodingException(f"Failed to decode pool id string: {e}") from e
+                    raise DecodingException(
+                        f"Failed to decode pool id string: {e}"
+                    ) from e
         return cls(PoolKeyHash.from_primitive(value))

--- a/test/pycardano/test_certificate.py
+++ b/test/pycardano/test_certificate.py
@@ -196,21 +196,29 @@ def test_drep_decode():
     vkey_hash = staking_key.to_verification_key().hash()
     drep = DRep(kind=DRepKind.VERIFICATION_KEY_HASH, credential=vkey_hash)
 
-    drep1 = DRep.decode(drep.id(IdFormat.CIP105))
-    drep2 = DRep.decode(drep.id())
+    drep.id_format = IdFormat.CIP105
+    drep1 = DRep.decode(str(drep))
+    drep.id_format = IdFormat.CIP129
+    drep2 = DRep.decode(str(drep))
 
     drep_id_cip105 = "drep1fq529kkm4972nlgvmjvewkyeguxzrx7upkpge7ndmakkjnstaxx"
     drep_id_cip129 = "drep1yfyz3gk6mw5he20apnwfn96cn9rscgvmmsxc9r86dh0k66gr0rurp"
     drep_id_hex = "4828a2dadba97ca9fd0cdc99975899470c219bdc0d828cfa6ddf6d69"
 
-    assert drep1.id(IdFormat.CIP105) == drep_id_cip105
-    assert drep1.id() == drep_id_cip129
+    drep1.id_format = IdFormat.CIP105
+    assert str(drep1) == drep_id_cip105
+    drep1.id_format = IdFormat.CIP129
+    assert str(drep1) == drep_id_cip129
 
-    assert drep2.id(IdFormat.CIP105) == drep_id_cip105
-    assert drep2.id() == drep_id_cip129
+    drep2.id_format = IdFormat.CIP105
+    assert str(drep2) == drep_id_cip105
+    drep2.id_format = IdFormat.CIP129
+    assert str(drep2) == drep_id_cip129
 
-    assert drep1.id_hex(IdFormat.CIP105) == drep_id_hex
-    assert drep2.id_hex(IdFormat.CIP105) == drep_id_hex
+    drep1.id_format = IdFormat.CIP105
+    assert bytes(drep1).hex() == drep_id_hex
+    drep2.id_format = IdFormat.CIP105
+    assert bytes(drep2).hex() == drep_id_hex
 
     assert drep == drep1
     assert drep == drep2
@@ -274,9 +282,12 @@ def test_drep_encode_decode_parametrized(
     drep = DRep(kind=drep_kind, credential=credential)
 
     # Act - Encode
-    encoded_cip105 = drep.id(IdFormat.CIP105)
-    encoded_cip129 = drep.id()
-    encoded_hex = drep.id_hex(IdFormat.CIP105)
+    drep.id_format = IdFormat.CIP105
+    encoded_cip105 = str(drep)
+    encoded_hex = bytes(drep).hex()
+
+    drep.id_format = IdFormat.CIP129
+    encoded_cip129 = str(drep)
 
     # Assert - Encoding
     assert encoded_cip105 == expected_cip105
@@ -296,18 +307,22 @@ def test_drep_encode_decode_parametrized(
         assert decoded_cip105 == drep
         assert decoded_cip105.kind == drep_kind
         assert decoded_cip105.credential == credential
-        assert decoded_cip105.id(IdFormat.CIP105) == expected_cip105
-        assert decoded_cip105.id() == expected_cip129
-        assert decoded_cip105.id_hex(IdFormat.CIP105) == expected_hex
+        decoded_cip105.id_format = IdFormat.CIP105
+        assert str(decoded_cip105) == expected_cip105
+        assert bytes(decoded_cip105).hex() == expected_hex
+        decoded_cip105.id_format = IdFormat.CIP129
+        assert str(decoded_cip105) == expected_cip129
 
         # Decode from CIP129 format
         decoded_cip129 = DRep.decode(expected_cip129)
         assert decoded_cip129 == drep
         assert decoded_cip129.kind == drep_kind
         assert decoded_cip129.credential == credential
-        assert decoded_cip129.id(IdFormat.CIP105) == expected_cip105
-        assert decoded_cip129.id() == expected_cip129
-        assert decoded_cip129.id_hex(IdFormat.CIP105) == expected_hex
+        decoded_cip129.id_format = IdFormat.CIP105
+        assert str(decoded_cip129) == expected_cip105
+        assert bytes(decoded_cip129).hex() == expected_hex
+        decoded_cip129.id_format = IdFormat.CIP129
+        assert str(decoded_cip129) == expected_cip129
 
         # Verify both decoded objects are equal
         assert decoded_cip105 == decoded_cip129

--- a/test/pycardano/test_certificate.py
+++ b/test/pycardano/test_certificate.py
@@ -18,7 +18,7 @@ from pycardano.certificate import (
     StakeDeregistration,
     StakeRegistration,
     UnregDRepCertificate,
-    UpdateDRepCertificate,
+    UpdateDRepCertificate, IdFormat,
 )
 from pycardano.exception import DeserializeException, InvalidArgumentException
 from pycardano.hash import (  # plutus_script_hash,
@@ -188,6 +188,130 @@ def test_anchor():
     assert Anchor.from_cbor(anchor_cbor_hex) == anchor
 
 
+def test_drep_decode():
+    staking_key = StakeSigningKey.from_cbor(
+        "5820ff3a330df8859e4e5f42a97fcaee73f6a00d0cf864f4bca902bd106d423f02c0"
+    )
+    vkey_hash = staking_key.to_verification_key().hash()
+    drep = DRep(kind=DRepKind.VERIFICATION_KEY_HASH, credential=vkey_hash)
+
+    drep1 = DRep.decode(drep.id(IdFormat.CIP105))
+    drep2 = DRep.decode(drep.id())
+
+    drep_id_cip105 = "drep1fq529kkm4972nlgvmjvewkyeguxzrx7upkpge7ndmakkjnstaxx"
+    drep_id_cip129 = "drep1yfyz3gk6mw5he20apnwfn96cn9rscgvmmsxc9r86dh0k66gr0rurp"
+    drep_id_hex = "4828a2dadba97ca9fd0cdc99975899470c219bdc0d828cfa6ddf6d69"
+
+    assert drep1.id(IdFormat.CIP105) == drep_id_cip105
+    assert drep1.id() == drep_id_cip129
+
+    assert drep2.id(IdFormat.CIP105) == drep_id_cip105
+    assert drep2.id() == drep_id_cip129
+
+    assert drep1.id_hex(IdFormat.CIP105) == drep_id_hex
+    assert drep2.id_hex(IdFormat.CIP105) == drep_id_hex
+
+    assert drep == drep1
+    assert drep == drep2
+    assert drep1 == drep2
+
+
+@pytest.mark.parametrize(
+    "drep_kind,credential,expected_cip105,expected_cip129,expected_hex,test_id",
+    [
+        # Happy path: VERIFICATION_KEY_HASH
+        (
+            DRepKind.VERIFICATION_KEY_HASH,
+            VerificationKeyHash(
+                bytes.fromhex(
+                    "4828a2dadba97ca9fd0cdc99975899470c219bdc0d828cfa6ddf6d69"
+                )
+            ),
+            "drep1fq529kkm4972nlgvmjvewkyeguxzrx7upkpge7ndmakkjnstaxx",
+            "drep1yfyz3gk6mw5he20apnwfn96cn9rscgvmmsxc9r86dh0k66gr0rurp",
+            "4828a2dadba97ca9fd0cdc99975899470c219bdc0d828cfa6ddf6d69",
+            "verification_key_hash",
+        ),
+        # Happy path: SCRIPT_HASH
+        (
+            DRepKind.SCRIPT_HASH,
+            ScriptHash(b"1" * SCRIPT_HASH_SIZE),
+            "drep_script1xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzarvrfk",
+            "drep1yvcnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzvf3xycnzvg4m7mek",
+            "31313131313131313131313131313131313131313131313131313131",
+            "script_hash",
+        ),
+        # Happy path: ALWAYS_ABSTAIN
+        (
+            DRepKind.ALWAYS_ABSTAIN,
+            None,
+            "drep_always_abstain",
+            "drep_always_abstain",
+            "",
+            "always_abstain",
+        ),
+        # Happy path: ALWAYS_NO_CONFIDENCE
+        (
+            DRepKind.ALWAYS_NO_CONFIDENCE,
+            None,
+            "drep_always_no_confidence",
+            "drep_always_no_confidence",
+            "",
+            "always_no_confidence",
+        ),
+    ],
+    ids=lambda p: p if isinstance(p, str) else None,
+)
+def test_drep_encode_decode_parametrized(
+    drep_kind, credential, expected_cip105, expected_cip129, expected_hex, test_id
+):
+    """Parametrized test for DRep encode/decode functionality.
+
+    Tests all DRep kinds with both CIP105 and CIP129 encoding formats.
+    """
+    # Arrange
+    drep = DRep(kind=drep_kind, credential=credential)
+
+    # Act - Encode
+    encoded_cip105 = drep.id(IdFormat.CIP105)
+    encoded_cip129 = drep.id()
+    encoded_hex = drep.id_hex(IdFormat.CIP105)
+
+    # Assert - Encoding
+    assert encoded_cip105 == expected_cip105
+    assert encoded_cip129 == expected_cip129
+    assert encoded_hex == expected_hex
+
+    # Act - Decode and verify round-trip
+    if drep_kind in (DRepKind.ALWAYS_ABSTAIN, DRepKind.ALWAYS_NO_CONFIDENCE):
+        # Special DReps only have one encoding format
+        decoded = DRep.decode(encoded_cip105)
+        assert decoded == drep
+        assert decoded.kind == drep_kind
+        assert decoded.credential is None
+    else:
+        # Decode from CIP105 format
+        decoded_cip105 = DRep.decode(expected_cip105)
+        assert decoded_cip105 == drep
+        assert decoded_cip105.kind == drep_kind
+        assert decoded_cip105.credential == credential
+        assert decoded_cip105.id(IdFormat.CIP105) == expected_cip105
+        assert decoded_cip105.id() == expected_cip129
+        assert decoded_cip105.id_hex(IdFormat.CIP105) == expected_hex
+
+        # Decode from CIP129 format
+        decoded_cip129 = DRep.decode(expected_cip129)
+        assert decoded_cip129 == drep
+        assert decoded_cip129.kind == drep_kind
+        assert decoded_cip129.credential == credential
+        assert decoded_cip129.id(IdFormat.CIP105) == expected_cip105
+        assert decoded_cip129.id() == expected_cip129
+        assert decoded_cip129.id_hex(IdFormat.CIP105) == expected_hex
+
+        # Verify both decoded objects are equal
+        assert decoded_cip105 == decoded_cip129
+
+
 def test_drep_credential():
     staking_key = StakeSigningKey.from_cbor(
         "5820ff3a330df8859e4e5f42a97fcaee73f6a00d0cf864f4bca902bd106d423f02c0"
@@ -280,7 +404,6 @@ def test_drep_credential():
 def test_drep_from_primitive(
     input_values, expected_kind, expected_credential, expected_exception, case_id
 ):
-
     # Arrange
     # (All input values are provided via test parameters)
 

--- a/test/pycardano/test_certificate.py
+++ b/test/pycardano/test_certificate.py
@@ -10,6 +10,7 @@ from pycardano.certificate import (
     DRep,
     DRepCredential,
     DRepKind,
+    IdFormat,
     PoolRegistration,
     PoolRetirement,
     ResignCommitteeColdCertificate,
@@ -18,7 +19,7 @@ from pycardano.certificate import (
     StakeDeregistration,
     StakeRegistration,
     UnregDRepCertificate,
-    UpdateDRepCertificate, IdFormat,
+    UpdateDRepCertificate,
 )
 from pycardano.exception import DeserializeException, InvalidArgumentException
 from pycardano.hash import (  # plutus_script_hash,

--- a/test/pycardano/test_governance.py
+++ b/test/pycardano/test_governance.py
@@ -3,7 +3,7 @@ from fractions import Fraction
 import pytest
 
 from pycardano.address import Address
-from pycardano.certificate import Anchor, StakeCredential, IdFormat
+from pycardano.certificate import Anchor, IdFormat, StakeCredential
 from pycardano.exception import DeserializeException
 from pycardano.governance import (
     CommitteeColdCredential,

--- a/test/pycardano/test_governance.py
+++ b/test/pycardano/test_governance.py
@@ -3,11 +3,12 @@ from fractions import Fraction
 import pytest
 
 from pycardano.address import Address
-from pycardano.certificate import Anchor, StakeCredential
+from pycardano.certificate import Anchor, StakeCredential, IdFormat
 from pycardano.exception import DeserializeException
 from pycardano.governance import (
     CommitteeColdCredential,
     CommitteeColdCredentialEpochMap,
+    CommitteeHotCredential,
     ExUnitPrices,
     GovActionId,
     GovActionIdToVotingProcedure,
@@ -68,6 +69,52 @@ class TestGovActionId:
         deserialized = GovActionId.from_primitive(primitive)
 
         assert deserialized == gov_action_id
+
+    def test_gov_action_id_decode(self):
+        transaction_id_1 = TransactionId(
+            bytes.fromhex(
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            )
+        )
+        gov_action_index_1 = 17
+        gov_id_bech32_1 = (
+            "gov_action1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpzklpgpf"
+        )
+        gov_id_hex_1 = (
+            "000000000000000000000000000000000000000000000000000000000000000011"
+        )
+
+        transaction_id_2 = TransactionId(
+            bytes.fromhex(
+                "1111111111111111111111111111111111111111111111111111111111111111"
+            )
+        )
+        gov_action_index_2 = 0
+        gov_id_bech32_2 = (
+            "gov_action1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsq6dmejn"
+        )
+        gov_id_hex_2 = (
+            "111111111111111111111111111111111111111111111111111111111111111100"
+        )
+
+        gov_action_id_1 = GovActionId(
+            transaction_id=transaction_id_1, gov_action_index=gov_action_index_1
+        )
+        decoded_gov_action_id_1 = GovActionId.decode(gov_id_bech32_1)
+
+        gov_action_id_2 = GovActionId(
+            transaction_id=transaction_id_2, gov_action_index=gov_action_index_2
+        )
+        decoded_gov_action_id_2 = GovActionId.decode(gov_id_bech32_2)
+
+        assert gov_action_id_1 == decoded_gov_action_id_1
+        assert gov_action_id_2 == decoded_gov_action_id_2
+
+        assert gov_action_id_1.id() == gov_id_bech32_1
+        assert gov_action_id_2.id() == gov_id_bech32_2
+
+        assert gov_action_id_1.id_hex() == gov_id_hex_1
+        assert gov_action_id_2.id_hex() == gov_id_hex_2
 
 
 class TestVote:
@@ -529,3 +576,27 @@ class TestProposalProcedure:
         assert deserialized.deposit == procedure.deposit
         assert deserialized.reward_account == procedure.reward_account
         assert deserialized.anchor == procedure.anchor
+
+
+class TestCommitteeCredentialEpochMap:
+    def test_committee_cold_credential(self):
+        key_hash = "00000000000000000000000000000000000000000000000000000000"
+        identifier = "1300000000000000000000000000000000000000000000000000000000"
+        bech32 = "cc_cold1zvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6kflvs"
+
+        credential = CommitteeColdCredential.decode(bech32)
+
+        assert credential.id() == bech32
+        assert credential.id_hex(IdFormat.CIP105) == key_hash
+        assert credential.id_hex() == identifier
+
+    def test_committee_hot_credential(self):
+        key_hash = "00000000000000000000000000000000000000000000000000000000"
+        identifier = "0200000000000000000000000000000000000000000000000000000000"
+        bech32 = "cc_hot1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvcdjk7"
+
+        credential = CommitteeHotCredential.decode(bech32)
+
+        assert credential.id() == bech32
+        assert credential.id_hex(IdFormat.CIP105) == key_hash
+        assert credential.id_hex() == identifier

--- a/test/pycardano/test_pool_params.py
+++ b/test/pycardano/test_pool_params.py
@@ -302,11 +302,10 @@ def test_pool_operator_id_property():
     pool_operator = PoolOperator(pool_key_hash)
 
     # Act
-    pool_id = pool_operator.id()
+    pool_id = str(pool_operator)
 
     # Assert
-    assert isinstance(pool_id, PoolId)
-    assert str(pool_id) == TEST_POOL_ID
+    assert pool_id == TEST_POOL_ID
 
 
 def test_pool_operator_id_hex_property():
@@ -317,10 +316,9 @@ def test_pool_operator_id_hex_property():
     pool_operator = PoolOperator(pool_key_hash)
 
     # Act
-    id_hex = pool_operator.id_hex()
+    id_hex = bytes(pool_operator).hex()
 
     # Assert
-    assert isinstance(id_hex, str)
     assert id_hex == pool_key_hash_hex
 
 
@@ -387,7 +385,7 @@ def test_pool_operator_from_primitive(input_value, description):
     # Assert
     assert isinstance(pool_operator, PoolOperator)
     assert (
-        pool_operator.id_hex()
+        bytes(pool_operator).hex()
         == "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
     )
 

--- a/test/pycardano/test_pool_params.py
+++ b/test/pycardano/test_pool_params.py
@@ -20,6 +20,7 @@ from pycardano.pool_params import (  # Fraction,
     MultiHostName,
     PoolId,
     PoolMetadata,
+    PoolOperator,
     PoolParams,
     SingleHostAddr,
     SingleHostName,
@@ -252,3 +253,188 @@ def test_pool_params(
     ]
 
     assert PoolParams.from_primitive(primitive_values).to_primitive() == primitive_out
+
+
+# PoolOperator Tests
+def test_pool_operator_initialization():
+    """Test PoolOperator can be initialized with a PoolKeyHash."""
+    # Arrange
+    pool_key_hash = PoolKeyHash(b"1" * POOL_KEY_HASH_SIZE)
+
+    # Act
+    pool_operator = PoolOperator(pool_key_hash)
+
+    # Assert
+    assert pool_operator.pool_key_hash == pool_key_hash
+
+
+def test_pool_operator_encode():
+    """Test PoolOperator can encode to bech32 format."""
+    # Arrange
+    pool_key_hash_hex = "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
+    pool_key_hash = PoolKeyHash(bytes.fromhex(pool_key_hash_hex))
+    pool_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    encoded = pool_operator.encode()
+
+    # Assert
+    assert encoded.startswith("pool")
+    assert isinstance(encoded, str)
+    assert encoded == TEST_POOL_ID
+
+
+def test_pool_operator_decode():
+    """Test PoolOperator can decode from bech32 format."""
+    # Act
+    pool_operator = PoolOperator.decode(TEST_POOL_ID)
+
+    # Assert
+    assert isinstance(pool_operator, PoolOperator)
+    assert pool_operator.encode() == TEST_POOL_ID
+
+
+def test_pool_operator_id_property():
+    """Test PoolOperator.id property returns a PoolId."""
+    # Arrange
+    pool_key_hash_hex = "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
+    pool_key_hash = PoolKeyHash(bytes.fromhex(pool_key_hash_hex))
+    pool_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    pool_id = pool_operator.id()
+
+    # Assert
+    assert isinstance(pool_id, PoolId)
+    assert str(pool_id) == TEST_POOL_ID
+
+
+def test_pool_operator_id_hex_property():
+    """Test PoolOperator.id_hex property returns hex string."""
+    # Arrange
+    pool_key_hash_hex = "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
+    pool_key_hash = PoolKeyHash(bytes.fromhex(pool_key_hash_hex))
+    pool_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    id_hex = pool_operator.id_hex()
+
+    # Assert
+    assert isinstance(id_hex, str)
+    assert id_hex == pool_key_hash_hex
+
+
+def test_pool_operator_repr():
+    """Test PoolOperator __repr__ returns encoded string."""
+    # Arrange
+    pool_key_hash_hex = "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
+    pool_key_hash = PoolKeyHash(bytes.fromhex(pool_key_hash_hex))
+    pool_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    repr_str = repr(pool_operator)
+
+    # Assert
+    assert repr_str == TEST_POOL_ID
+
+
+def test_pool_operator_bytes():
+    """Test PoolOperator __bytes__ returns pool key hash payload."""
+    # Arrange
+    pool_key_hash_hex = "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
+    pool_key_hash = PoolKeyHash(bytes.fromhex(pool_key_hash_hex))
+    pool_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    bytes_result = bytes(pool_operator)
+
+    # Assert
+    assert isinstance(bytes_result, bytes)
+    assert bytes_result == bytes.fromhex(pool_key_hash_hex)
+
+
+def test_pool_operator_to_primitive():
+    """Test PoolOperator.to_primitive returns bytes."""
+    # Arrange
+    pool_key_hash_hex = "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
+    pool_key_hash = PoolKeyHash(bytes.fromhex(pool_key_hash_hex))
+    pool_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    primitive = pool_operator.to_primitive()
+
+    # Assert
+    assert isinstance(primitive, bytes)
+    assert primitive == bytes.fromhex(pool_key_hash_hex)
+
+
+@pytest.mark.parametrize(
+    "input_value, description",
+    [
+        (TEST_POOL_ID, "bech32 pool id"),
+        ("dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22", "hex string"),
+        (
+            bytes.fromhex("dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"),
+            "bytes",
+        ),
+    ],
+)
+def test_pool_operator_from_primitive(input_value, description):
+    """Test PoolOperator.from_primitive handles different input formats."""
+    # Act
+    pool_operator = PoolOperator.from_primitive(input_value)
+
+    # Assert
+    assert isinstance(pool_operator, PoolOperator)
+    assert (
+        pool_operator.id_hex()
+        == "dacf06a23e4aaf119024e63deb79861ca175b24e7d44d97fb92b1a22"
+    )
+
+
+def test_pool_operator_roundtrip_bech32():
+    """Test PoolOperator can encode and decode maintaining consistency."""
+    # Arrange
+    pool_key_hash = PoolKeyHash(b"1" * POOL_KEY_HASH_SIZE)
+    original_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    encoded = original_operator.encode()
+    decoded_operator = PoolOperator.decode(encoded)
+
+    # Assert
+    assert decoded_operator.pool_key_hash == original_operator.pool_key_hash
+    assert decoded_operator.encode() == encoded
+
+
+def test_pool_operator_roundtrip_primitive():
+    """Test PoolOperator serialization roundtrip."""
+    # Arrange
+    pool_key_hash = PoolKeyHash(b"2" * POOL_KEY_HASH_SIZE)
+    original_operator = PoolOperator(pool_key_hash)
+
+    # Act
+    primitive = original_operator.to_primitive()
+    restored_operator = PoolOperator.from_primitive(primitive)
+
+    # Assert
+    assert restored_operator.pool_key_hash == original_operator.pool_key_hash
+    assert restored_operator.to_primitive() == primitive
+
+
+@pytest.mark.parametrize(
+    "invalid_input, expected_exception",
+    [
+        ("invalid_pool_id", Exception),  # Invalid hex string
+        (
+            "stake1uxtr5m6kygt77399zxqrykkluqr0grr4yrjtl5xplza6k8q5fghrp",
+            Exception,
+        ),  # Wrong prefix
+        ("", Exception),  # Empty string
+    ],
+)
+def test_pool_operator_from_primitive_errors(invalid_input, expected_exception):
+    """Test PoolOperator.from_primitive raises errors for invalid inputs."""
+    # Act & Assert
+    with pytest.raises(expected_exception):
+        PoolOperator.from_primitive(invalid_input)


### PR DESCRIPTION
This pull request introduces enhanced support for Bech32 encoding/decoding for representing DRep credentials, committee credentials, pool operators, and governance action IDs. These changes also include support for both [CIP105](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0105/README.md) and [CIP129](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0129/README.md) variations.

Governance and DRep credential improvements:
* Added new classes: `GovernanceCredential` and `GovernanceKeyType`, with support for Bech32 encoding/decoding, hex representation, and credential type identification. Also updated `DRepCredential` to inherit from `GovernanceCredential`. [[1]](diffhunk://#diff-915d157493041622c5810f5956d8fc6d6c8729beceb836465c8fd2be1a5841ddR51-R52) [[2]](diffhunk://#diff-915d157493041622c5810f5956d8fc6d6c8729beceb836465c8fd2be1a5841ddR109-R273)
* Enhanced the `DRep` class with methods for encoding/decoding DRep IDs in Bech32 and hex formats, and improved error handling. [[1]](diffhunk://#diff-915d157493041622c5810f5956d8fc6d6c8729beceb836465c8fd2be1a5841ddR308-R329) [[2]](diffhunk://#diff-915d157493041622c5810f5956d8fc6d6c8729beceb836465c8fd2be1a5841ddR347-R403)

Governance action and committee credential enhancements:
* Added `CommitteeHotCredential` and updated `CommitteeColdCredential` to inherit from `GovernanceCredential`, supporting Bech32 encoding. [[1]](diffhunk://#diff-58c5028cc568a2f1874e73231fd20b573f6fd3d5c4fdbb25034f19b8ddc9058dR29) [[2]](diffhunk://#diff-58c5028cc568a2f1874e73231fd20b573f6fd3d5c4fdbb25034f19b8ddc9058dL50-R65)
* Implemented encoding/decoding methods for `GovActionId`, allowing Bech32 and hex representations for governance action IDs.

Pool operator improvements:
* Introduced the `PoolOperator` class with Bech32 encoding/decoding, hex representation, and primitive conversion methods for pool key hashes. [[1]](diffhunk://#diff-0bf051bbf82fcbfa0e069b6b2ab143bd1eb53709f14af7286456bb41d47a033aR31) [[2]](diffhunk://#diff-0bf051bbf82fcbfa0e069b6b2ab143bd1eb53709f14af7286456bb41d47a033aR251-R332)

Supporting changes:
* Added constant for `CIP129_PAYLOAD_SIZE` to support new credential formats. [[1]](diffhunk://#diff-3997949d84a4f35461c0d3a41d538e9b7397659ea0e51eba0a065b04fdb63e59R18) [[2]](diffhunk://#diff-3997949d84a4f35461c0d3a41d538e9b7397659ea0e51eba0a065b04fdb63e59R46)
* Updated imports and error handling throughout affected files. [[1]](diffhunk://#diff-915d157493041622c5810f5956d8fc6d6c8729beceb836465c8fd2be1a5841ddL7-R20) [[2]](diffhunk://#diff-0bf051bbf82fcbfa0e069b6b2ab143bd1eb53709f14af7286456bb41d47a033aL12-R13) [[3]](diffhunk://#diff-58c5028cc568a2f1874e73231fd20b573f6fd3d5c4fdbb25034f19b8ddc9058dL8-R14) [[4]](diffhunk://#diff-dc67157a6febe1891d471626a6909e00b8d66dc497a5746027932ac2f975fcd6L21-R21)