### PR TITLE
Fix decode_array double-reading length bytes for arrays with 24+ items

### DIFF
--- a/pycardano/serialization.py
+++ b/pycardano/serialization.py
@@ -196,9 +196,9 @@ CBORBase = TypeVar("CBORBase", bound="CBORSerializable")
 
 def decode_array(self, subtype: int) -> Sequence[Any]:
     # Major tag 4
-    length = self._decode_length(subtype, allow_indefinite=True)
-
-    if length is None:
+    if subtype == 31:
+        # Indefinite length array — delegate to the original decoder, then wrap
+        # the result in IndefiniteFrozenList to preserve indefinite encoding.
         ret = IndefiniteFrozenList(list(self.decode_array(subtype=subtype)))
         ret.freeze()
         return ret


### PR DESCRIPTION
The custom decode_array override in serialization.py called _decode_length to check for indefinite-length arrays, then delegated to the original decode_array which called _decode_length again. For arrays with fewer than 24 items, the length is encoded directly in the subtype (no stream bytes consumed), so the double call was harmless. For 24+ items, CBOR uses multi-byte length encoding (e.g. 98 18 for 24 items) and _decode_length reads from the stream — the second call consumed actual array content as a length byte, corrupting the decode.

Replace the _decode_length call with a simple subtype == 31 check, which is sufficient to detect indefinite-length arrays without consuming any bytes from the stream.

This bug only affected cbor2pure, not the cbor2 C extension.