### PR TITLE
Ignore macOS metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist
 .mypy_cache
 coverage.xml
 .cbor2_version
+.DS_Store
 
 # IDE
 .idea


### PR DESCRIPTION
Add a repository-wide `.DS_Store` ignore rule.