### PR TITLE
Fix Poetry environment for integration tests

### DIFF
--- a/integration-test/run_tests.sh
+++ b/integration-test/run_tests.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 ROOT=$(pwd)
 
-poetry install -C ..
+(cd .. && poetry install)
 #poetry run pip install ogmios
 
 ##########


### PR DESCRIPTION
## Summary

- install dependencies while the working directory is the repository root
- avoid the Poetry relative -C bug that writes #!.venv/bin/python into console-script shebangs
- restore poetry run pytest from the integration-test directory

Poetry bug: https://github.com/python-poetry/poetry/issues/10541

## Testing

- bash -n integration-test/run_tests.sh
- reproduced the pre-fix Command not found: pytest failure with Poetry 2.4.2
- verified the patched install creates an absolute pytest shebang
- verified Poetry 2.4.2 can run pytest --version from integration-test